### PR TITLE
596: Fixing FileContent field is not viewable

### DIFF
--- a/config/defaults/secure-open-banking/managed-objects/filePaymentsIntent.json
+++ b/config/defaults/secure-open-banking/managed-objects/filePaymentsIntent.json
@@ -567,6 +567,7 @@
           "FileContent": {
             "title": "File content",
             "type": "string",
+            "viewable": true,
             "description": "File content",
             "isVirtual": false
           },


### PR DESCRIPTION
Issue: https://github.com/secureapigateway/secureapigateway/issues/596
Description: Fixed FileContent field not viewable on filePaymentIntent IDM object.