### PR TITLE
592: add idempotent support for payment consents

### DIFF
--- a/config/defaults/secure-open-banking/managed-objects/domesticPaymentIntent.json
+++ b/config/defaults/secure-open-banking/managed-objects/domesticPaymentIntent.json
@@ -64,17 +64,6 @@
                     "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource.",
                     "nullable": false
                   },
-                  "IdempotencyKey": {
-                    "title": "Idempotency key",
-                    "type": "string",
-                    "viewable": true,
-                    "searchable": true,
-                    "userEditable": false,
-                    "minLength": 1,
-                    "maxLength": 128,
-                    "description": "OB: Header value of 'x-idempotency-key' sent in the request as unique request identification to recognize if the request is the same as early",
-                    "nullable": false
-                  },
                   "CreationDateTime": {
                     "title": "Creation Date Time",
                     "type": "string",
@@ -712,7 +701,6 @@
                 },
                 "order": [
                   "ConsentId",
-                  "IdempotencyKey",
                   "CreationDateTime",
                   "Status",
                   "StatusUpdateDateTime",
@@ -727,7 +715,6 @@
                 ],
                 "required": [
                   "ConsentId",
-                  "IdempotencyKey",
                   "CreationDateTime",
                   "Status",
                   "StatusUpdateDateTime",
@@ -1091,6 +1078,17 @@
             "description": "Account id",
             "minLength": null,
             "isVirtual": false
+          },
+          "IdempotencyKey": {
+            "title": "Idempotency key",
+            "type": "string",
+            "viewable": true,
+            "searchable": true,
+            "userEditable": false,
+            "minLength": 1,
+            "maxLength": 128,
+            "description": "OB: Header value of 'x-idempotency-key' sent in the request as unique request identification to recognize if the request is the same as early",
+            "nullable": false
           }
         },
         "order": [
@@ -1098,12 +1096,14 @@
           "OBIntentObjectType",
           "OBIntentObject",
           "user",
-          "apiClient"
+          "apiClient",
+          "IdempotencyKey"
         ],
         "required": [
           "OBIntentObjectType",
           "OBVersion",
-          "OBIntentObject"
+          "OBIntentObject",
+          "IdempotencyKey"
         ]
       },
       "iconClass": "fa fa-database",

--- a/config/defaults/secure-open-banking/managed-objects/domesticScheduledPaymentIntent.json
+++ b/config/defaults/secure-open-banking/managed-objects/domesticScheduledPaymentIntent.json
@@ -64,17 +64,6 @@
                     "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource.",
                     "nullable": false
                   },
-                  "IdempotencyKey": {
-                    "title": "Idempotency key",
-                    "type": "string",
-                    "viewable": true,
-                    "searchable": true,
-                    "userEditable": false,
-                    "minLength": 1,
-                    "maxLength": 128,
-                    "description": "OB: Header value of 'x-idempotency-key' sent in the request as unique request identification to recognize if the request is the same as early",
-                    "nullable": false
-                  },
                   "CreationDateTime": {
                     "title": "Creation Date Time",
                     "type": "string",
@@ -732,7 +721,6 @@
                 },
                 "order": [
                   "ConsentId",
-                  "IdempotencyKey",
                   "CreationDateTime",
                   "Status",
                   "StatusUpdateDateTime",
@@ -748,7 +736,6 @@
                 ],
                 "required": [
                   "ConsentId",
-                  "IdempotencyKey",
                   "CreationDateTime",
                   "Status",
                   "StatusUpdateDateTime",
@@ -1113,6 +1100,17 @@
             "description": "Account id",
             "minLength": null,
             "isVirtual": false
+          },
+          "IdempotencyKey": {
+            "title": "Idempotency key",
+            "type": "string",
+            "viewable": true,
+            "searchable": true,
+            "userEditable": false,
+            "minLength": 1,
+            "maxLength": 128,
+            "description": "OB: Header value of 'x-idempotency-key' sent in the request as unique request identification to recognize if the request is the same as early",
+            "nullable": false
           }
         },
         "order": [
@@ -1120,12 +1118,14 @@
           "OBIntentObjectType",
           "OBIntentObject",
           "user",
-          "apiClient"
+          "apiClient",
+          "IdempotencyKey"
         ],
         "required": [
           "OBVersion",
           "OBIntentObjectType",
-          "OBIntentObject"
+          "OBIntentObject",
+          "IdempotencyKey"
         ]
       },
       "iconClass": "fa fa-database",

--- a/config/defaults/secure-open-banking/managed-objects/domesticStandingOrdersIntent.json
+++ b/config/defaults/secure-open-banking/managed-objects/domesticStandingOrdersIntent.json
@@ -64,17 +64,6 @@
                     "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource.",
                     "nullable": false
                   },
-                  "IdempotencyKey": {
-                    "title": "Idempotency key",
-                    "type": "string",
-                    "viewable": true,
-                    "searchable": true,
-                    "userEditable": false,
-                    "minLength": 1,
-                    "maxLength": 128,
-                    "description": "OB: Header value of 'x-idempotency-key' sent in the request as unique request identification to recognize if the request is the same as early",
-                    "nullable": false
-                  },
                   "CreationDateTime": {
                     "title": "Creation Date Time",
                     "type": "string",
@@ -698,7 +687,6 @@
                 },
                 "order": [
                   "ConsentId",
-                  "IdempotencyKey",
                   "CreationDateTime",
                   "Status",
                   "StatusUpdateDateTime",
@@ -713,7 +701,6 @@
                 ],
                 "required": [
                   "ConsentId",
-                  "IdempotencyKey",
                   "CreationDateTime",
                   "Status",
                   "StatusUpdateDateTime",
@@ -1078,6 +1065,17 @@
             "description": "Account id",
             "minLength": null,
             "isVirtual": false
+          },
+          "IdempotencyKey": {
+            "title": "Idempotency key",
+            "type": "string",
+            "viewable": true,
+            "searchable": true,
+            "userEditable": false,
+            "minLength": 1,
+            "maxLength": 128,
+            "description": "OB: Header value of 'x-idempotency-key' sent in the request as unique request identification to recognize if the request is the same as early",
+            "nullable": false
           }
         },
         "order": [
@@ -1085,12 +1083,14 @@
           "OBIntentObjectType",
           "OBIntentObject",
           "user",
-          "apiClient"
+          "apiClient",
+          "IdempotencyKey"
         ],
         "required": [
           "OBVersion",
           "OBIntentObjectType",
-          "OBIntentObject"
+          "OBIntentObject",
+          "IdempotencyKey"
         ]
       },
       "iconClass": "fa fa-database",

--- a/config/defaults/secure-open-banking/managed-objects/domesticVrpPaymentIntent.json
+++ b/config/defaults/secure-open-banking/managed-objects/domesticVrpPaymentIntent.json
@@ -64,17 +64,6 @@
                     "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource.",
                     "nullable": false
                   },
-                  "IdempotencyKey": {
-                    "title": "Idempotency key",
-                    "type": "string",
-                    "viewable": true,
-                    "searchable": true,
-                    "userEditable": false,
-                    "minLength": 1,
-                    "maxLength": 128,
-                    "description": "OB: Header value of 'x-idempotency-key' sent in the request as unique request identification to recognize if the request is the same as early",
-                    "nullable": false
-                  },
                   "CreationDateTime": {
                     "title": "Creation Date Time",
                     "type": "string",
@@ -631,7 +620,6 @@
                 },
                 "order": [
                   "ConsentId",
-                  "IdempotencyKey",
                   "CreationDateTime",
                   "Status",
                   "StatusUpdateDateTime",
@@ -641,7 +629,6 @@
                 ],
                 "required": [
                   "ConsentId",
-                  "IdempotencyKey",
                   "CreationDateTime",
                   "Status",
                   "StatusUpdateDateTime",
@@ -1048,6 +1035,17 @@
             "description": "Account id",
             "minLength": null,
             "isVirtual": false
+          },
+          "IdempotencyKey": {
+            "title": "Idempotency key",
+            "type": "string",
+            "viewable": true,
+            "searchable": true,
+            "userEditable": false,
+            "minLength": 1,
+            "maxLength": 128,
+            "description": "OB: Header value of 'x-idempotency-key' sent in the request as unique request identification to recognize if the request is the same as early",
+            "nullable": false
           }
         },
         "order": [
@@ -1055,12 +1053,14 @@
           "OBIntentObjectType",
           "OBIntentObject",
           "user",
-          "apiClient"
+          "apiClient",
+          "IdempotencyKey"
         ],
         "required": [
           "OBVersion",
           "OBIntentObjectType",
-          "OBIntentObject"
+          "OBIntentObject",
+          "IdempotencyKey"
         ]
       },
       "iconClass": "fa fa-database",

--- a/config/defaults/secure-open-banking/managed-objects/filePaymentsIntent.json
+++ b/config/defaults/secure-open-banking/managed-objects/filePaymentsIntent.json
@@ -53,17 +53,6 @@
                 "isVirtual": false,
                 "nullable": false,
                 "properties": {
-                  "IdempotencyKey": {
-                    "title": "Idempotency key",
-                    "type": "string",
-                    "viewable": true,
-                    "searchable": true,
-                    "userEditable": false,
-                    "minLength": 1,
-                    "maxLength": 128,
-                    "description": "OB: Header value of 'x-idempotency-key' sent in the request as unique request identification to recognize if the request is the same as early",
-                    "nullable": false
-                  },
                   "Initiation": {
                     "title": "Initiation",
                     "type": "object",
@@ -359,13 +348,11 @@
                   }
                 },
                 "order": [
-                  "IdempotencyKey",
                   "Initiation",
                   "Authorisation",
                   "SCASupportData"
                 ],
                 "required": [
-                  "IdempotencyKey",
                   "Initiation"
                 ]
               },
@@ -582,6 +569,17 @@
             "type": "string",
             "description": "File content",
             "isVirtual": false
+          },
+          "IdempotencyKey": {
+            "title": "Idempotency key",
+            "type": "string",
+            "viewable": true,
+            "searchable": true,
+            "userEditable": false,
+            "minLength": 1,
+            "maxLength": 128,
+            "description": "OB: Header value of 'x-idempotency-key' sent in the request as unique request identification to recognize if the request is the same as early",
+            "nullable": false
           }
         },
         "order": [
@@ -589,12 +587,16 @@
           "OBIntentObjectType",
           "OBIntentObject",
           "user",
-          "apiClient"
+          "apiClient",
+          "AccountId",
+          "FileContent",
+          "IdempotencyKey"
         ],
         "required": [
           "OBVersion",
           "OBIntentObjectType",
-          "OBIntentObject"
+          "OBIntentObject",
+          "IdempotencyKey"
         ]
       },
       "iconClass": "fa fa-database",

--- a/config/defaults/secure-open-banking/managed-objects/internationalPaymentIntent.json
+++ b/config/defaults/secure-open-banking/managed-objects/internationalPaymentIntent.json
@@ -64,17 +64,6 @@
                     "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource.",
                     "nullable": false
                   },
-                  "IdempotencyKey": {
-                    "title": "Idempotency key",
-                    "type": "string",
-                    "viewable": true,
-                    "searchable": true,
-                    "userEditable": false,
-                    "minLength": 1,
-                    "maxLength": 128,
-                    "description": "OB: Header value of 'x-idempotency-key' sent in the request as unique request identification to recognize if the request is the same as early",
-                    "nullable": false
-                  },
                   "CreationDateTime": {
                     "title": "Creation Date Time",
                     "type": "string",
@@ -1175,7 +1164,6 @@
                 },
                 "order": [
                   "ConsentId",
-                  "IdempotencyKey",
                   "CreationDateTime",
                   "Status",
                   "StatusUpdateDateTime",
@@ -1192,7 +1180,6 @@
                 ],
                 "required": [
                   "ConsentId",
-                  "IdempotencyKey",
                   "CreationDateTime",
                   "Status",
                   "StatusUpdateDateTime",
@@ -1556,6 +1543,17 @@
             "description": "Account id",
             "minLength": null,
             "isVirtual": false
+          },
+          "IdempotencyKey": {
+            "title": "Idempotency key",
+            "type": "string",
+            "viewable": true,
+            "searchable": true,
+            "userEditable": false,
+            "minLength": 1,
+            "maxLength": 128,
+            "description": "OB: Header value of 'x-idempotency-key' sent in the request as unique request identification to recognize if the request is the same as early",
+            "nullable": false
           }
         },
         "order": [
@@ -1563,12 +1561,14 @@
           "OBIntentObjectType",
           "OBIntentObject",
           "user",
-          "apiClient"
+          "apiClient",
+          "IdempotencyKey"
         ],
         "required": [
           "OBVersion",
           "OBIntentObjectType",
-          "OBIntentObject"
+          "OBIntentObject",
+          "IdempotencyKey"
         ]
       },
       "iconClass": "fa fa-database",

--- a/config/defaults/secure-open-banking/managed-objects/internationalScheduledPaymentIntent.json
+++ b/config/defaults/secure-open-banking/managed-objects/internationalScheduledPaymentIntent.json
@@ -64,17 +64,6 @@
                     "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource.",
                     "nullable": false
                   },
-                  "IdempotencyKey": {
-                    "title": "Idempotency key",
-                    "type": "string",
-                    "viewable": true,
-                    "searchable": true,
-                    "userEditable": false,
-                    "minLength": 1,
-                    "maxLength": 128,
-                    "description": "OB: Header value of 'x-idempotency-key' sent in the request as unique request identification to recognize if the request is the same as early",
-                    "nullable": false
-                  },
                   "CreationDateTime": {
                     "title": "Creation Date Time",
                     "type": "string",
@@ -1196,7 +1185,6 @@
                 },
                 "order": [
                   "ConsentId",
-                  "IdempotencyKey",
                   "CreationDateTime",
                   "Status",
                   "StatusUpdateDateTime",
@@ -1214,7 +1202,6 @@
                 ],
                 "required": [
                   "ConsentId",
-                  "IdempotencyKey",
                   "CreationDateTime",
                   "Status",
                   "StatusUpdateDateTime",
@@ -1586,12 +1573,14 @@
           "OBIntentObjectType",
           "OBIntentObject",
           "user",
-          "apiClient"
+          "apiClient",
+          "IdempotencyKey"
         ],
         "required": [
           "OBVersion",
           "OBIntentObjectType",
-          "OBIntentObject"
+          "OBIntentObject",
+          "IdempotencyKey"
         ]
       },
       "iconClass": "fa fa-database",

--- a/config/defaults/secure-open-banking/managed-objects/internationalStandingOrdersIntent.json
+++ b/config/defaults/secure-open-banking/managed-objects/internationalStandingOrdersIntent.json
@@ -64,17 +64,6 @@
                     "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource.",
                     "nullable": false
                   },
-                  "IdempotencyKey": {
-                    "title": "Idempotency key",
-                    "type": "string",
-                    "viewable": true,
-                    "searchable": true,
-                    "userEditable": false,
-                    "minLength": 1,
-                    "maxLength": 128,
-                    "description": "OB: Header value of 'x-idempotency-key' sent in the request as unique request identification to recognize if the request is the same as early",
-                    "nullable": false
-                  },
                   "CreationDateTime": {
                     "title": "Creation Date Time",
                     "type": "string",
@@ -1017,7 +1006,6 @@
                 },
                 "order": [
                   "ConsentId",
-                  "IdempotencyKey",
                   "CreationDateTime",
                   "Status",
                   "StatusUpdateDateTime",
@@ -1033,7 +1021,6 @@
                 ],
                 "required": [
                   "ConsentId",
-                  "IdempotencyKey",
                   "CreationDateTime",
                   "Status",
                   "StatusUpdateDateTime",
@@ -1398,6 +1385,17 @@
             "description": "Account id",
             "minLength": null,
             "isVirtual": false
+          },
+          "IdempotencyKey": {
+            "title": "Idempotency key",
+            "type": "string",
+            "viewable": true,
+            "searchable": true,
+            "userEditable": false,
+            "minLength": 1,
+            "maxLength": 128,
+            "description": "OB: Header value of 'x-idempotency-key' sent in the request as unique request identification to recognize if the request is the same as early",
+            "nullable": false
           }
         },
         "order": [
@@ -1405,12 +1403,14 @@
           "OBIntentObjectType",
           "OBIntentObject",
           "user",
-          "apiClient"
+          "apiClient",
+          "IdempotencyKey"
         ],
         "required": [
           "OBVersion",
           "OBIntentObjectType",
-          "OBIntentObject"
+          "OBIntentObject",
+          "IdempotencyKey"
         ]
       },
       "iconClass": "fa fa-database",


### PR DESCRIPTION
- Added 'IdempotencyKey' property as mandatory for all payment consentsbjects
Issue: https://github.com/secureapigateway/secureapigateway/issues/592