### PR TITLE
948: Added new optional fields to Risk in payment managed objects

### DIFF
--- a/sapig-overlay/managed-objects/domesticPaymentIntent/domesticPaymentIntent.json
+++ b/sapig-overlay/managed-objects/domesticPaymentIntent/domesticPaymentIntent.json
@@ -822,7 +822,11 @@
               "PaymentContextCode",
               "MerchantCategoryCode",
               "MerchantCustomerIdentification",
-              "DeliveryAddress"
+              "DeliveryAddress",
+              "ContractPresentInidicator",
+              "BeneficiaryPrepopulatedIndicator",
+              "PaymentPurposeCode",
+              "BeneficiaryAccountType"
             ],
             "properties": {
               "DeliveryAddress": {
@@ -956,6 +960,42 @@
                 "type": "string",
                 "userEditable": true,
                 "viewable": true
+              },
+              "ContractPresentInidicator": {
+                "title": "ContractPresentInidicator",
+                "type": "boolean",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Indicates if Payee has a contractual relationship with the PISP.",
+                "isVirtual": false
+              },
+              "BeneficiaryPrepopulatedIndicator": {
+                "title": "BeneficiaryPrepopulatedIndicator",
+                "type": "boolean",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Indicates if PISP has immutably prepopulated payment details in for the PSU.",
+                "isVirtual": false
+              },
+              "PaymentPurposeCode": {
+                "title": "PaymentPurposeCode",
+                "type": "string",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Category code, related to the type of services or goods that corresponds to the underlying purpose of the payment that conforms to Recommended UK Purpose Code in ISO 20022 Payment Messaging List.",
+                "isVirtual": false
+              },
+              "BeneficiaryAccountType": {
+                "title": "BeneficiaryAccountType",
+                "type": "string",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "To be provided if the AccountType is known.",
+                "isVirtual": false
               }
             },
             "searchable": false,

--- a/sapig-overlay/managed-objects/domesticScheduledPaymentIntent/domesticScheduledPaymentIntent.json
+++ b/sapig-overlay/managed-objects/domesticScheduledPaymentIntent/domesticScheduledPaymentIntent.json
@@ -845,7 +845,11 @@
               "PaymentContextCode",
               "MerchantCategoryCode",
               "MerchantCustomerIdentification",
-              "DeliveryAddress"
+              "DeliveryAddress",
+              "ContractPresentInidicator",
+              "BeneficiaryPrepopulatedIndicator",
+              "PaymentPurposeCode",
+              "BeneficiaryAccountType"
             ],
             "properties": {
               "DeliveryAddress": {
@@ -979,6 +983,42 @@
                 "type": "string",
                 "userEditable": true,
                 "viewable": true
+              },
+              "ContractPresentInidicator": {
+                "title": "ContractPresentInidicator",
+                "type": "boolean",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Indicates if Payee has a contractual relationship with the PISP.",
+                "isVirtual": false
+              },
+              "BeneficiaryPrepopulatedIndicator": {
+                "title": "BeneficiaryPrepopulatedIndicator",
+                "type": "boolean",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Indicates if PISP has immutably prepopulated payment details in for the PSU.",
+                "isVirtual": false
+              },
+              "PaymentPurposeCode": {
+                "title": "PaymentPurposeCode",
+                "type": "string",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Category code, related to the type of services or goods that corresponds to the underlying purpose of the payment that conforms to Recommended UK Purpose Code in ISO 20022 Payment Messaging List.",
+                "isVirtual": false
+              },
+              "BeneficiaryAccountType": {
+                "title": "BeneficiaryAccountType",
+                "type": "string",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "To be provided if the AccountType is known.",
+                "isVirtual": false
               }
             },
             "searchable": false,

--- a/sapig-overlay/managed-objects/domesticStandingOrdersIntent/domesticStandingOrdersIntent.json
+++ b/sapig-overlay/managed-objects/domesticStandingOrdersIntent/domesticStandingOrdersIntent.json
@@ -810,7 +810,11 @@
               "PaymentContextCode",
               "MerchantCategoryCode",
               "MerchantCustomerIdentification",
-              "DeliveryAddress"
+              "DeliveryAddress",
+              "ContractPresentInidicator",
+              "BeneficiaryPrepopulatedIndicator",
+              "PaymentPurposeCode",
+              "BeneficiaryAccountType"
             ],
             "properties": {
               "DeliveryAddress": {
@@ -944,6 +948,42 @@
                 "type": "string",
                 "userEditable": true,
                 "viewable": true
+              },
+              "ContractPresentInidicator": {
+                "title": "ContractPresentInidicator",
+                "type": "boolean",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Indicates if Payee has a contractual relationship with the PISP.",
+                "isVirtual": false
+              },
+              "BeneficiaryPrepopulatedIndicator": {
+                "title": "BeneficiaryPrepopulatedIndicator",
+                "type": "boolean",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Indicates if PISP has immutably prepopulated payment details in for the PSU.",
+                "isVirtual": false
+              },
+              "PaymentPurposeCode": {
+                "title": "PaymentPurposeCode",
+                "type": "string",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Category code, related to the type of services or goods that corresponds to the underlying purpose of the payment that conforms to Recommended UK Purpose Code in ISO 20022 Payment Messaging List.",
+                "isVirtual": false
+              },
+              "BeneficiaryAccountType": {
+                "title": "BeneficiaryAccountType",
+                "type": "string",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "To be provided if the AccountType is known.",
+                "isVirtual": false
               }
             },
             "searchable": false,

--- a/sapig-overlay/managed-objects/domesticVrpPaymentIntent/domesticVrpPaymentIntent.json
+++ b/sapig-overlay/managed-objects/domesticVrpPaymentIntent/domesticVrpPaymentIntent.json
@@ -739,7 +739,7 @@
               "PaymentPurposeCode",
               "MerchantCategoryCode",
               "MerchantCustomerIdentification",
-              "ContractPresentInidicator",
+              "ContractPresentIndicator",
               "BeneficiaryPrepopulatedIndicator",
               "BeneficiaryAccountType",
               "DeliveryAddress"
@@ -763,7 +763,7 @@
                 "userEditable": true,
                 "viewable": true
               },
-              "ContractPresentInidicator": {
+              "ContractPresentIndicator": {
                 "description": "Indicates if Payee has a contractual relationship with the PISP.",
                 "isVirtual": false,
                 "searchable": false,

--- a/sapig-overlay/managed-objects/domesticVrpPaymentIntent/domesticVrpPaymentIntent.json
+++ b/sapig-overlay/managed-objects/domesticVrpPaymentIntent/domesticVrpPaymentIntent.json
@@ -739,7 +739,7 @@
               "PaymentPurposeCode",
               "MerchantCategoryCode",
               "MerchantCustomerIdentification",
-              "ContractPresentIndicator",
+              "ContractPresentInidicator",
               "BeneficiaryPrepopulatedIndicator",
               "BeneficiaryAccountType",
               "DeliveryAddress"
@@ -763,7 +763,7 @@
                 "userEditable": true,
                 "viewable": true
               },
-              "ContractPresentIndicator": {
+              "ContractPresentInidicator": {
                 "description": "Indicates if Payee has a contractual relationship with the PISP.",
                 "isVirtual": false,
                 "searchable": false,

--- a/sapig-overlay/managed-objects/internationalPaymentIntent/internationalPaymentIntent.json
+++ b/sapig-overlay/managed-objects/internationalPaymentIntent/internationalPaymentIntent.json
@@ -1288,7 +1288,11 @@
               "PaymentContextCode",
               "MerchantCategoryCode",
               "MerchantCustomerIdentification",
-              "DeliveryAddress"
+              "DeliveryAddress",
+              "ContractPresentInidicator",
+              "BeneficiaryPrepopulatedIndicator",
+              "PaymentPurposeCode",
+              "BeneficiaryAccountType"
             ],
             "properties": {
               "DeliveryAddress": {
@@ -1422,6 +1426,42 @@
                 "type": "string",
                 "userEditable": true,
                 "viewable": true
+              },
+              "ContractPresentInidicator": {
+                "title": "ContractPresentInidicator",
+                "type": "boolean",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Indicates if Payee has a contractual relationship with the PISP.",
+                "isVirtual": false
+              },
+              "BeneficiaryPrepopulatedIndicator": {
+                "title": "BeneficiaryPrepopulatedIndicator",
+                "type": "boolean",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Indicates if PISP has immutably prepopulated payment details in for the PSU.",
+                "isVirtual": false
+              },
+              "PaymentPurposeCode": {
+                "title": "PaymentPurposeCode",
+                "type": "string",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Category code, related to the type of services or goods that corresponds to the underlying purpose of the payment that conforms to Recommended UK Purpose Code in ISO 20022 Payment Messaging List.",
+                "isVirtual": false
+              },
+              "BeneficiaryAccountType": {
+                "title": "BeneficiaryAccountType",
+                "type": "string",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "To be provided if the AccountType is known.",
+                "isVirtual": false
               }
             },
             "searchable": false,

--- a/sapig-overlay/managed-objects/internationalScheduledPaymentIntent/internationalScheduledPaymentIntent.json
+++ b/sapig-overlay/managed-objects/internationalScheduledPaymentIntent/internationalScheduledPaymentIntent.json
@@ -1311,7 +1311,11 @@
               "PaymentContextCode",
               "MerchantCategoryCode",
               "MerchantCustomerIdentification",
-              "DeliveryAddress"
+              "DeliveryAddress",
+              "ContractPresentInidicator",
+              "BeneficiaryPrepopulatedIndicator",
+              "PaymentPurposeCode",
+              "BeneficiaryAccountType"
             ],
             "properties": {
               "DeliveryAddress": {
@@ -1445,6 +1449,42 @@
                 "type": "string",
                 "userEditable": true,
                 "viewable": true
+              },
+              "ContractPresentInidicator": {
+                "title": "ContractPresentInidicator",
+                "type": "boolean",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Indicates if Payee has a contractual relationship with the PISP.",
+                "isVirtual": false
+              },
+              "BeneficiaryPrepopulatedIndicator": {
+                "title": "BeneficiaryPrepopulatedIndicator",
+                "type": "boolean",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Indicates if PISP has immutably prepopulated payment details in for the PSU.",
+                "isVirtual": false
+              },
+              "PaymentPurposeCode": {
+                "title": "PaymentPurposeCode",
+                "type": "string",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Category code, related to the type of services or goods that corresponds to the underlying purpose of the payment that conforms to Recommended UK Purpose Code in ISO 20022 Payment Messaging List.",
+                "isVirtual": false
+              },
+              "BeneficiaryAccountType": {
+                "title": "BeneficiaryAccountType",
+                "type": "string",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "To be provided if the AccountType is known.",
+                "isVirtual": false
               }
             },
             "searchable": false,

--- a/sapig-overlay/managed-objects/internationalStandingOrdersIntent/internationalStandingOrdersIntent.json
+++ b/sapig-overlay/managed-objects/internationalStandingOrdersIntent/internationalStandingOrdersIntent.json
@@ -1130,7 +1130,11 @@
               "PaymentContextCode",
               "MerchantCategoryCode",
               "MerchantCustomerIdentification",
-              "DeliveryAddress"
+              "DeliveryAddress",
+              "ContractPresentInidicator",
+              "BeneficiaryPrepopulatedIndicator",
+              "PaymentPurposeCode",
+              "BeneficiaryAccountType"
             ],
             "properties": {
               "DeliveryAddress": {
@@ -1264,6 +1268,42 @@
                 "type": "string",
                 "userEditable": true,
                 "viewable": true
+              },
+              "ContractPresentInidicator": {
+                "title": "ContractPresentInidicator",
+                "type": "boolean",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Indicates if Payee has a contractual relationship with the PISP.",
+                "isVirtual": false
+              },
+              "BeneficiaryPrepopulatedIndicator": {
+                "title": "BeneficiaryPrepopulatedIndicator",
+                "type": "boolean",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Indicates if PISP has immutably prepopulated payment details in for the PSU.",
+                "isVirtual": false
+              },
+              "PaymentPurposeCode": {
+                "title": "PaymentPurposeCode",
+                "type": "string",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Category code, related to the type of services or goods that corresponds to the underlying purpose of the payment that conforms to Recommended UK Purpose Code in ISO 20022 Payment Messaging List.",
+                "isVirtual": false
+              },
+              "BeneficiaryAccountType": {
+                "title": "BeneficiaryAccountType",
+                "type": "string",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "To be provided if the AccountType is known.",
+                "isVirtual": false
               }
             },
             "searchable": false,


### PR DESCRIPTION
- Added new optional fields to Risk in payment managed objects to match with expected fields defined in version 3.1.10

Issue: https://github.com/secureapigateway/secureapigateway/issues/948