### PR TITLE
1275: Configuring the OAuth2.0 Provider supportedAuthorizationResponseSigningAlgorithms to only support PS256

### DIFF
--- a/sapig-overlay/realms/alpha/services/oauth-oidc.json
+++ b/sapig-overlay/realms/alpha/services/oauth-oidc.json
@@ -67,19 +67,7 @@
       "PS256"
     ],
     "supportedAuthorizationResponseSigningAlgorithms": [
-      "PS384",
-      "RS384",
-      "EdDSA",
-      "ES384",
-      "HS256",
-      "HS512",
-      "ES256",
-      "RS256",
-      "HS384",
-      "ES512",
-      "PS256",
-      "PS512",
-      "RS512"
+      "PS256"
     ],
     "supportedUserInfoEncryptionEnc": [
       "A256GCM",


### PR DESCRIPTION
Adding supportedAuthorizationResponseSigningAlgorithms to control the signing algorithms supported for signing JARM responses. Setting this to PS256 as this is FAPI compliant.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1275