### PR TITLE
1300: Creating SAPI-G core platform config

### DIFF
--- a/sapig-overlay/core/.env.sample
+++ b/sapig-overlay/core/.env.sample
@@ -1,0 +1,62 @@
+# Sample environment for FIDC config management
+
+# Base URL of tenant
+TENANT_BASE_URL=
+
+# Directory to write configuration data to
+CONFIG_DIR=./
+
+# Realms to pull config from
+REALMS=["alpha"]
+
+# Script prefix - only pull scripts with matching names
+SCRIPT_PREFIXES=[]
+
+#
+# Service account settings
+#
+
+# Service account ID
+SERVICE_ACCOUNT_ID=
+
+# System wide OAuth2 client ID for service account
+SERVICE_ACCOUNT_CLIENT_ID=service-account
+
+# Scope to request for service account access
+SERVICE_ACCOUNT_SCOPE=fr:idm:* fr:am:* fr:idc:esv:*
+
+# JWK based service account private key
+SERVICE_ACCOUNT_KEY=
+
+AUTHZ_TYPE=SERVICE_ACCOUNT
+
+
+OAUTH2_AGENTS='{
+  "alpha": {
+    "IdentityGatewayAgent": ["ig-agent"],
+    "OAuth2Client": ["ig-client"],
+    "SoftwarePublisher": ["Secure API Gateway Development Trusted Directory"]
+  },
+  "bravo": {
+  }
+}'
+
+# ESV Variables - the below values need to be supplied when doing fr-config-push variables
+
+#ESV_BASEURL=
+#ESV_MTLS_BASEURL=
+#ESV_CORS_ACCEPTED_ORIGINS=
+#ESV_IDENTITY_CLOUD_BASEURL=
+#ESV_SAPIG_IDENTITY_CLOUD_REALM=
+
+# ESV Secrets - the below values need to be supplied when doing fr-config-push secrets
+#ESV_AM_OAUTH2_CA_CERTS_1=
+
+#ESV_IG_AGENT_USERNAME_1=
+#ESV_IG_AGENT_PASSWORD_1=
+
+#ESV_IG_CLIENT_USERNAME_1=
+#ESV_IG_CLIENT_PASSWORD_1=
+
+#ESV_IG_IDM_ADMIN_USERNAME_1=
+#ESV_IG_IDM_ADMIN_PASSWORD_1=

--- a/sapig-overlay/core/cors/cors-config.json
+++ b/sapig-overlay/core/cors/cors-config.json
@@ -1,0 +1,106 @@
+{
+  "corsServiceGlobal": {
+    "_id": "",
+    "_rev": "515901845",
+    "enabled": true,
+    "_type": {
+      "_id": "CorsService",
+      "name": "CORS Service",
+      "collection": false
+    }
+  },
+  "corsServices": [
+    {
+      "maxAge": 0,
+      "exposedHeaders": [
+        "Cache-Control",
+        "Content-Language",
+        "Expires",
+        "Last-Modified",
+        "Pragma",
+        "Content-Type",
+        "cache-control",
+        "content-api-version",
+        "content-length",
+        "date",
+        "etag",
+        "expires",
+        "pragma",
+        "set-cookie",
+        "strict-transport-security",
+        "x-content-type-options",
+        "x-forgerock-transactionid",
+        "x-frame-options",
+        "Access-Control-Allow-Origin"
+      ],
+      "acceptedHeaders": [
+        "Accept",
+        "accept-api-version",
+        "Referer",
+        "sec-ch-ua",
+        "sec-ch-ua-moblie",
+        "sec-ch-ua-platform",
+        "User-Agent",
+        "iPlanetDirectoryPro",
+        "Content-Type",
+        "authority",
+        "method",
+        "path",
+        "scheme",
+        "accept",
+        "accept-encoding",
+        "accept-language",
+        "referer",
+        "sec-fetch-dest",
+        "sec-fetch-mode",
+        "sec-fetch-site",
+        "user-agent",
+        "cookie",
+        "sec-fetch-user",
+        "upgrade-insecure-requests",
+        "authorization",
+        "x-requested-with",
+        "x-forgerock-transactionid"
+      ],
+      "allowCredentials": true,
+      "acceptedMethods": [
+        "POST",
+        "PUT",
+        "GET",
+        "DELETE",
+        "PATCH",
+        "FETCH",
+        "OPTIONS"
+      ],
+      "acceptedOrigins": {
+        "$list": "&{esv.cors.accepted.origins}"
+      },
+      "enabled": true,
+      "_id": "login-ui-cors",
+      "_type": {
+        "_id": "configuration",
+        "name": "Cors Configuration",
+        "collection": true
+      }
+    }
+  ],
+  "idmCorsConfig": {
+    "_id": "servletfilter/cors",
+    "classPathURLs": [],
+    "filterClass": "org.eclipse.jetty.servlets.CrossOriginFilter",
+    "initParams": {
+      "allowCredentials": false,
+      "allowedHeaders": "authorization,accept,content-type,origin,x-requested-with,cache-control,accept-api-version",
+      "allowedMethods": "GET,POST,PUT,DELETE,PATCH",
+      "allowedOrigins": "*",
+      "chainPreflight": false,
+      "exposedHeaders": "WWW-Authenticate"
+    },
+    "requestAttributes": {},
+    "scriptExtensions": {},
+    "systemProperties": {},
+    "urlPatterns": [
+      "/*"
+    ]
+  }
+}

--- a/sapig-overlay/core/esvs/secrets/esv-am-oauth2-ca-certs.json
+++ b/sapig-overlay/core/esvs/secrets/esv-am-oauth2-ca-certs.json
@@ -1,0 +1,12 @@
+{
+  "_id": "esv-am-oauth2-ca-certs",
+  "encoding": "pem",
+  "useInPlaceholders": false,
+  "description": "",
+  "versions": [
+    {
+      "version": "1",
+      "valueBase64": "${ESV_AM_OAUTH2_CA_CERTS_1}"
+    }
+  ]
+}

--- a/sapig-overlay/core/esvs/secrets/esv-ig-agent-password.json
+++ b/sapig-overlay/core/esvs/secrets/esv-ig-agent-password.json
@@ -1,0 +1,12 @@
+{
+  "_id": "esv-ig-agent-password",
+  "encoding": "generic",
+  "useInPlaceholders": true,
+  "description": "",
+  "versions": [
+    {
+      "version": "1",
+      "valueBase64": "${ESV_IG_AGENT_PASSWORD_1}"
+    }
+  ]
+}

--- a/sapig-overlay/core/esvs/secrets/esv-ig-agent-username.json
+++ b/sapig-overlay/core/esvs/secrets/esv-ig-agent-username.json
@@ -1,0 +1,12 @@
+{
+  "_id": "esv-ig-agent-username",
+  "encoding": "generic",
+  "useInPlaceholders": true,
+  "description": "",
+  "versions": [
+    {
+      "version": "1",
+      "valueBase64": "${ESV_IG_AGENT_USERNAME_1}"
+    }
+  ]
+}

--- a/sapig-overlay/core/esvs/secrets/esv-ig-client-password.json
+++ b/sapig-overlay/core/esvs/secrets/esv-ig-client-password.json
@@ -1,0 +1,12 @@
+{
+  "_id": "esv-ig-client-password",
+  "encoding": "generic",
+  "useInPlaceholders": true,
+  "description": "",
+  "versions": [
+    {
+      "version": "1",
+      "valueBase64": "${ESV_IG_CLIENT_PASSWORD_1}"
+    }
+  ]
+}

--- a/sapig-overlay/core/esvs/secrets/esv-ig-client-username.json
+++ b/sapig-overlay/core/esvs/secrets/esv-ig-client-username.json
@@ -1,0 +1,12 @@
+{
+  "_id": "esv-ig-client-username",
+  "encoding": "generic",
+  "useInPlaceholders": true,
+  "description": "",
+  "versions": [
+    {
+      "version": "1",
+      "valueBase64": "${ESV_IG_CLIENT_USERNAME_1}"
+    }
+  ]
+}

--- a/sapig-overlay/core/esvs/secrets/esv-ig-idm-admin-password.json
+++ b/sapig-overlay/core/esvs/secrets/esv-ig-idm-admin-password.json
@@ -1,0 +1,12 @@
+{
+  "_id": "esv-ig-idm-admin-password",
+  "encoding": "generic",
+  "useInPlaceholders": true,
+  "description": "",
+  "versions": [
+    {
+      "version": "1",
+      "valueBase64": "${ESV_IG_IDM_ADMIN_PASSWORD_1}"
+    }
+  ]
+}

--- a/sapig-overlay/core/esvs/secrets/esv-ig-idm-admin-username.json
+++ b/sapig-overlay/core/esvs/secrets/esv-ig-idm-admin-username.json
@@ -1,0 +1,12 @@
+{
+  "_id": "esv-ig-idm-admin-username",
+  "encoding": "generic",
+  "useInPlaceholders": true,
+  "description": "",
+  "versions": [
+    {
+      "version": "1",
+      "valueBase64": "${ESV_IG_IDM_ADMIN_USERNAME_1}"
+    }
+  ]
+}

--- a/sapig-overlay/core/esvs/variables/esv-baseurl.json
+++ b/sapig-overlay/core/esvs/variables/esv-baseurl.json
@@ -1,0 +1,6 @@
+{
+  "_id": "esv-baseurl",
+  "expressionType": "string",
+  "description": "",
+  "valueBase64": "${ESV_BASEURL}"
+}

--- a/sapig-overlay/core/esvs/variables/esv-cors-accepted-origins.json
+++ b/sapig-overlay/core/esvs/variables/esv-cors-accepted-origins.json
@@ -1,0 +1,6 @@
+{
+  "_id": "esv-cors-accepted-origins",
+  "expressionType": "list",
+  "description": "",
+  "valueBase64": "${ESV_CORS_ACCEPTED_ORIGINS}"
+}

--- a/sapig-overlay/core/esvs/variables/esv-identity-cloud-baseurl.json
+++ b/sapig-overlay/core/esvs/variables/esv-identity-cloud-baseurl.json
@@ -1,0 +1,6 @@
+{
+  "_id": "esv-identity-cloud-baseurl",
+  "expressionType": "string",
+  "description": "",
+  "valueBase64": "${ESV_IDENTITY_CLOUD_BASEURL}"
+}

--- a/sapig-overlay/core/esvs/variables/esv-mtls-baseurl.json
+++ b/sapig-overlay/core/esvs/variables/esv-mtls-baseurl.json
@@ -1,0 +1,6 @@
+{
+  "_id": "esv-mtls-baseurl",
+  "expressionType": "string",
+  "description": "",
+  "valueBase64": "${ESV_MTLS_BASEURL}"
+}

--- a/sapig-overlay/core/esvs/variables/esv-sapig-identity-cloud-realm.json
+++ b/sapig-overlay/core/esvs/variables/esv-sapig-identity-cloud-realm.json
@@ -1,0 +1,6 @@
+{
+  "_id": "esv-sapig-identity-cloud-realm",
+  "expressionType": "string",
+  "description": "",
+  "valueBase64": "${ESV_SAPIG_IDENTITY_CLOUD_REALM}"
+}

--- a/sapig-overlay/core/internal-roles/Alpha Admin.json
+++ b/sapig-overlay/core/internal-roles/Alpha Admin.json
@@ -1,0 +1,295 @@
+{
+  "_id": "0b6d39c0-e95a-424b-b6f3-db3ea9a3da9b",
+  "_rev": "00000000673513bb",
+  "condition": null,
+  "description": null,
+  "name": "Alpha Admin",
+  "privileges": [
+    {
+      "path": "managed/alpha_user",
+      "name": "Alpha realm - Users",
+      "actions": [],
+      "permissions": [
+        "VIEW",
+        "CREATE",
+        "UPDATE",
+        "DELETE"
+      ],
+      "accessFlags": [
+        {
+          "attribute": "userName",
+          "readOnly": false
+        },
+        {
+          "attribute": "password",
+          "readOnly": false
+        },
+        {
+          "attribute": "givenName",
+          "readOnly": false
+        },
+        {
+          "attribute": "cn",
+          "readOnly": false
+        },
+        {
+          "attribute": "sn",
+          "readOnly": false
+        },
+        {
+          "attribute": "mail",
+          "readOnly": false
+        },
+        {
+          "attribute": "description",
+          "readOnly": false
+        },
+        {
+          "attribute": "accountStatus",
+          "readOnly": false
+        },
+        {
+          "attribute": "telephoneNumber",
+          "readOnly": false
+        },
+        {
+          "attribute": "postalAddress",
+          "readOnly": false
+        },
+        {
+          "attribute": "city",
+          "readOnly": false
+        },
+        {
+          "attribute": "postalCode",
+          "readOnly": false
+        },
+        {
+          "attribute": "country",
+          "readOnly": false
+        },
+        {
+          "attribute": "stateProvince",
+          "readOnly": false
+        },
+        {
+          "attribute": "roles",
+          "readOnly": false
+        },
+        {
+          "attribute": "manager",
+          "readOnly": false
+        },
+        {
+          "attribute": "authzRoles",
+          "readOnly": false
+        },
+        {
+          "attribute": "reports",
+          "readOnly": false
+        },
+        {
+          "attribute": "effectiveRoles",
+          "readOnly": false
+        },
+        {
+          "attribute": "effectiveAssignments",
+          "readOnly": false
+        },
+        {
+          "attribute": "lastSync",
+          "readOnly": false
+        },
+        {
+          "attribute": "kbaInfo",
+          "readOnly": false
+        },
+        {
+          "attribute": "preferences",
+          "readOnly": false
+        },
+        {
+          "attribute": "consentedMappings",
+          "readOnly": false
+        },
+        {
+          "attribute": "ownerOfOrg",
+          "readOnly": false
+        },
+        {
+          "attribute": "adminOfOrg",
+          "readOnly": false
+        },
+        {
+          "attribute": "memberOfOrg",
+          "readOnly": false
+        },
+        {
+          "attribute": "memberOfOrgIDs",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedString1",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedString2",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedString3",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedString4",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedString5",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedString1",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedString2",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedString3",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedString4",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedString5",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedMultivalued1",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedMultivalued2",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedMultivalued3",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedMultivalued4",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedMultivalued5",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedMultivalued1",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedMultivalued2",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedMultivalued3",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedMultivalued4",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedMultivalued5",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedDate1",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedDate2",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedDate3",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedDate4",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedDate5",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedDate1",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedDate2",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedDate3",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedDate4",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedDate5",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedInteger1",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedInteger2",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedInteger3",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedInteger4",
+          "readOnly": false
+        },
+        {
+          "attribute": "frIndexedInteger5",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedInteger1",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedInteger2",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedInteger3",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedInteger4",
+          "readOnly": false
+        },
+        {
+          "attribute": "frUnindexedInteger5",
+          "readOnly": false
+        }
+      ]
+    }
+  ],
+  "temporalConstraints": []
+}

--- a/sapig-overlay/core/internal-roles/organisation-view.json
+++ b/sapig-overlay/core/internal-roles/organisation-view.json
@@ -1,0 +1,72 @@
+{
+  "_id": "eb2aa22d-0ee1-4a08-be24-fb5849af1101",
+  "_rev": "00000000be4232e5",
+  "condition": null,
+  "description": null,
+  "name": "organisation-view",
+  "privileges": [
+    {
+      "path": "managed/alpha_organization",
+      "name": "Alpha realm - Organizations",
+      "actions": [],
+      "permissions": [
+        "VIEW"
+      ],
+      "accessFlags": [
+        {
+          "attribute": "name",
+          "readOnly": true
+        },
+        {
+          "attribute": "description",
+          "readOnly": true
+        },
+        {
+          "attribute": "owners",
+          "readOnly": true
+        },
+        {
+          "attribute": "admins",
+          "readOnly": true
+        },
+        {
+          "attribute": "members",
+          "readOnly": true
+        },
+        {
+          "attribute": "parent",
+          "readOnly": true
+        },
+        {
+          "attribute": "children",
+          "readOnly": true
+        },
+        {
+          "attribute": "adminIDs",
+          "readOnly": true
+        },
+        {
+          "attribute": "ownerIDs",
+          "readOnly": true
+        },
+        {
+          "attribute": "parentAdminIDs",
+          "readOnly": true
+        },
+        {
+          "attribute": "parentOwnerIDs",
+          "readOnly": true
+        },
+        {
+          "attribute": "parentIDs",
+          "readOnly": true
+        },
+        {
+          "attribute": "number",
+          "readOnly": true
+        }
+      ]
+    }
+  ],
+  "temporalConstraints": []
+}

--- a/sapig-overlay/core/managed-objects/apiClient/apiClient.json
+++ b/sapig-overlay/core/managed-objects/apiClient/apiClient.json
@@ -1,0 +1,177 @@
+{
+  "name": "apiClient",
+  "schema": {
+    "$schema": "http://forgerock.org/json-schema#",
+    "type": "object",
+    "title": "apiClient",
+    "description": "Secure Banking apiClient",
+    "icon": "fa-cogs",
+    "properties": {
+      "_id": {
+        "title": "IDM Internal ID",
+        "type": "string",
+        "viewable": true,
+        "searchable": true,
+        "userEditable": true,
+        "description": null,
+        "isVirtual": false,
+        "deleteQueryConfig": false
+      },
+      "id": {
+        "title": "API Client ID",
+        "type": "string",
+        "viewable": true,
+        "searchable": true,
+        "userEditable": true,
+        "description": null,
+        "isVirtual": false,
+        "deleteQueryConfig": false
+      },
+      "name": {
+        "title": "API Client Name",
+        "type": "string",
+        "viewable": true,
+        "searchable": true,
+        "userEditable": true
+      },
+      "description": {
+        "title": "Description",
+        "type": "string",
+        "viewable": true,
+        "searchable": true,
+        "userEditable": true
+      },
+      "logoUri": {
+        "title": "Logo URI",
+        "type": "string",
+        "viewable": true,
+        "searchable": true,
+        "userEditable": true
+      },
+      "jwksUri": {
+        "title": "JWKS URI",
+        "type": "string",
+        "viewable": true,
+        "searchable": true,
+        "userEditable": true
+      },
+      "jwks": {
+        "title": "JWK Set",
+        "type": "object",
+        "viewable": true,
+        "searchable": false,
+        "userEditable": false
+      },
+      "roles": {
+        "title": "Roles",
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "viewable": true,
+        "searchable": false,
+        "userEditable": true
+      },
+      "ssa": {
+        "title": "Software Statement Assertion",
+        "type": "string",
+        "viewable": true,
+        "searchable": true,
+        "userEditable": true,
+        "description": null,
+        "minLength": null,
+        "isVirtual": false
+      },
+      "apiClientOrg": {
+        "title": "API Client Organisation",
+        "type": "relationship",
+        "viewable": true,
+        "searchable": false,
+        "userEditable": false,
+        "returnByDefault": false,
+        "reverseRelationship": true,
+        "reversePropertyName": "apiClients",
+        "validate": false,
+        "properties": {
+          "_ref": {
+            "type": "string"
+          },
+          "_refProperties": {
+            "type": "object",
+            "properties": {
+              "_id": {
+                "type": "string",
+                "required": false,
+                "propName": "_id"
+              }
+            }
+          }
+        },
+        "resourceCollection": [
+          {
+            "path": "managed/apiClientOrg",
+            "label": "apiClientorg",
+            "query": {
+              "queryFilter": "true",
+              "fields": [
+                "id",
+                "name"
+              ],
+              "sortKeys": []
+            },
+            "notify": false
+          }
+        ],
+        "description": null,
+        "requiredByParent": false,
+        "isVirtual": false,
+        "notifySelf": false,
+        "referencedRelationshipFields": null,
+        "referencedObjectFields": null,
+        "deleteQueryConfig": false
+      },
+      "oauth2ClientId": {
+        "title": "OAuth2 Client ID",
+        "type": "string",
+        "viewable": true,
+        "searchable": true,
+        "userEditable": true,
+        "description": "OAuth2 Client ID",
+        "isVirtual": false,
+        "deleteQueryConfig": false
+      },
+      "deleted": {
+        "title": "Deleted",
+        "type": "boolean",
+        "viewable": true,
+        "searchable": true,
+        "userEditable": true,
+        "description": "Has the ApiClient record been deleted",
+        "isVirtual": false,
+        "default": false
+      }
+    },
+    "order": [
+      "_id",
+      "id",
+      "name",
+      "description",
+      "deleted",
+      "logoUri",
+      "jwksUri",
+      "ssa",
+      "apiClientOrg",
+      "oauth2ClientId"
+    ],
+    "required": [
+      "id",
+      "name",
+      "oauth2ClientId",
+      "ssa",
+      "deleted"
+    ],
+    "mat-icon": null
+  },
+  "iconClass": "fa fa-database",
+  "type": "Managed Object"
+}

--- a/sapig-overlay/core/managed-objects/apiClientOrg/apiClientOrg.json
+++ b/sapig-overlay/core/managed-objects/apiClientOrg/apiClientOrg.json
@@ -1,0 +1,116 @@
+{
+  "iconClass": "fa fa-database",
+  "name": "apiClientOrg",
+  "schema": {
+    "$schema": "http://forgerock.org/json-schema#",
+    "description": "apiClientOrg Details",
+    "icon": "fa-bank",
+    "mat-icon": "",
+    "order": [
+      "name",
+      "id",
+      "created",
+      "_id",
+      "apiClients"
+    ],
+    "properties": {
+      "_id": {
+        "description": null,
+        "isVirtual": false,
+        "minLength": null,
+        "searchable": false,
+        "title": "Internal IDM Identifier",
+        "type": "string",
+        "userEditable": false,
+        "viewable": true
+      },
+      "apiClients": {
+        "deleteQueryConfig": false,
+        "description": null,
+        "isVirtual": false,
+        "items": {
+          "notifySelf": false,
+          "properties": {
+            "_ref": {
+              "type": "string"
+            },
+            "_refProperties": {
+              "properties": {
+                "_id": {
+                  "propName": "_id",
+                  "required": false,
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "resourceCollection": [
+            {
+              "label": "apiClient",
+              "notify": false,
+              "path": "managed/apiClient",
+              "query": {
+                "fields": [],
+                "queryFilter": "true",
+                "sortKeys": []
+              }
+            }
+          ],
+          "reversePropertyName": "apiClientOrg",
+          "reverseRelationship": true,
+          "type": "relationship",
+          "validate": false
+        },
+        "minLength": null,
+        "policies": [],
+        "referencedObjectFields": null,
+        "referencedRelationshipFields": null,
+        "requiredByParent": false,
+        "returnByDefault": false,
+        "searchable": false,
+        "title": "API Clients",
+        "type": "array",
+        "userEditable": false,
+        "viewable": true
+      },
+      "created": {
+        "searchable": true,
+        "title": "Timestamp",
+        "type": "string",
+        "userEditable": true,
+        "viewable": true
+      },
+      "id": {
+        "deleteQueryConfig": false,
+        "description": "API Client Organisation ID",
+        "isVirtual": false,
+        "policies": [
+          {
+            "params": {},
+            "policyId": "unique"
+          }
+        ],
+        "searchable": true,
+        "title": "API Client Organisation ID",
+        "type": "string",
+        "userEditable": true,
+        "viewable": true
+      },
+      "name": {
+        "deleteQueryConfig": false,
+        "description": "API Client Organisation Name",
+        "isVirtual": false,
+        "searchable": true,
+        "title": "API Client Organisation Name",
+        "type": "string",
+        "userEditable": true,
+        "viewable": true
+      }
+    },
+    "required": [],
+    "title": "apiClientOrg",
+    "type": "object"
+  },
+  "type": "Managed Object"
+}

--- a/sapig-overlay/core/realms/alpha/journeys/PSD2 Customer Authentication/PSD2 Customer Authentication.json
+++ b/sapig-overlay/core/realms/alpha/journeys/PSD2 Customer Authentication/PSD2 Customer Authentication.json
@@ -1,0 +1,42 @@
+{
+  "_id": "PSD2 Customer Authentication",
+  "_rev": "691293967",
+  "uiConfig": {},
+  "entryNodeId": "9ea6a7ef-518a-4586-8f76-71865b1d0b18",
+  "nodes": {
+    "9ea6a7ef-518a-4586-8f76-71865b1d0b18": {
+      "connections": {
+        "outcome": "f41f02b1-bb10-429d-8743-8c22d81898ac"
+      },
+      "displayName": "Page Node",
+      "nodeType": "PageNode",
+      "x": 194,
+      "y": 253.015625
+    },
+    "f41f02b1-bb10-429d-8743-8c22d81898ac": {
+      "connections": {
+        "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+        "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+      },
+      "displayName": "Data Store Decision",
+      "nodeType": "DataStoreDecisionNode",
+      "x": 486,
+      "y": 242.015625
+    }
+  },
+  "staticNodes": {
+    "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+      "x": 807,
+      "y": 157
+    },
+    "e301438c-0bd0-429c-ab0c-66126501069a": {
+      "x": 794,
+      "y": 307
+    },
+    "startNode": {
+      "x": 50,
+      "y": 250
+    }
+  },
+  "enabled": true
+}

--- a/sapig-overlay/core/realms/alpha/journeys/PSD2 Customer Authentication/nodes/Data Store Decision - f41f02b1-bb10-429d-8743-8c22d81898ac.json
+++ b/sapig-overlay/core/realms/alpha/journeys/PSD2 Customer Authentication/nodes/Data Store Decision - f41f02b1-bb10-429d-8743-8c22d81898ac.json
@@ -1,0 +1,19 @@
+{
+  "_id": "f41f02b1-bb10-429d-8743-8c22d81898ac",
+  "_rev": "-1744860878",
+  "_type": {
+    "_id": "DataStoreDecisionNode",
+    "name": "Data Store Decision",
+    "collection": true
+  },
+  "_outcomes": [
+    {
+      "id": "true",
+      "displayName": "True"
+    },
+    {
+      "id": "false",
+      "displayName": "False"
+    }
+  ]
+}

--- a/sapig-overlay/core/realms/alpha/journeys/PSD2 Customer Authentication/nodes/Page Node - 9ea6a7ef-518a-4586-8f76-71865b1d0b18.json
+++ b/sapig-overlay/core/realms/alpha/journeys/PSD2 Customer Authentication/nodes/Page Node - 9ea6a7ef-518a-4586-8f76-71865b1d0b18.json
@@ -1,0 +1,29 @@
+{
+  "_id": "9ea6a7ef-518a-4586-8f76-71865b1d0b18",
+  "_rev": "593125899",
+  "nodes": [
+    {
+      "_id": "ada9ef86-d550-4591-b9dc-5751e7adbb62",
+      "nodeType": "UsernameCollectorNode",
+      "displayName": "Username Collector"
+    },
+    {
+      "_id": "1db869b1-09de-4a8e-b340-e0563891c3bf",
+      "nodeType": "PasswordCollectorNode",
+      "displayName": "Password Collector"
+    }
+  ],
+  "pageDescription": {},
+  "pageHeader": {},
+  "_type": {
+    "_id": "PageNode",
+    "name": "Page Node",
+    "collection": true
+  },
+  "_outcomes": [
+    {
+      "id": "outcome",
+      "displayName": "Outcome"
+    }
+  ]
+}

--- a/sapig-overlay/core/realms/alpha/journeys/PSD2 Customer Authentication/nodes/Page Node - 9ea6a7ef-518a-4586-8f76-71865b1d0b18/Password Collector - 1db869b1-09de-4a8e-b340-e0563891c3bf.json
+++ b/sapig-overlay/core/realms/alpha/journeys/PSD2 Customer Authentication/nodes/Page Node - 9ea6a7ef-518a-4586-8f76-71865b1d0b18/Password Collector - 1db869b1-09de-4a8e-b340-e0563891c3bf.json
@@ -1,0 +1,15 @@
+{
+  "_id": "1db869b1-09de-4a8e-b340-e0563891c3bf",
+  "_rev": "1278861132",
+  "_type": {
+    "_id": "PasswordCollectorNode",
+    "name": "Password Collector",
+    "collection": true
+  },
+  "_outcomes": [
+    {
+      "id": "outcome",
+      "displayName": "Outcome"
+    }
+  ]
+}

--- a/sapig-overlay/core/realms/alpha/journeys/PSD2 Customer Authentication/nodes/Page Node - 9ea6a7ef-518a-4586-8f76-71865b1d0b18/Username Collector - ada9ef86-d550-4591-b9dc-5751e7adbb62.json
+++ b/sapig-overlay/core/realms/alpha/journeys/PSD2 Customer Authentication/nodes/Page Node - 9ea6a7ef-518a-4586-8f76-71865b1d0b18/Username Collector - ada9ef86-d550-4591-b9dc-5751e7adbb62.json
@@ -1,0 +1,15 @@
+{
+  "_id": "ada9ef86-d550-4591-b9dc-5751e7adbb62",
+  "_rev": "2111256055",
+  "_type": {
+    "_id": "UsernameCollectorNode",
+    "name": "Username Collector",
+    "collection": true
+  },
+  "_outcomes": [
+    {
+      "id": "outcome",
+      "displayName": "Outcome"
+    }
+  ]
+}

--- a/sapig-overlay/core/realms/alpha/journeys/PSD2 Secure Customer Authentication/PSD2 Secure Customer Authentication.json
+++ b/sapig-overlay/core/realms/alpha/journeys/PSD2 Secure Customer Authentication/PSD2 Secure Customer Authentication.json
@@ -1,0 +1,51 @@
+{
+  "_id": "PSD2 Secure Customer Authentication",
+  "_rev": "-262290789",
+  "uiConfig": {},
+  "entryNodeId": "ee0efdc1-9fba-4323-95ef-ec468f6ad30c",
+  "nodes": {
+    "4785b3c1-5dc9-4883-b01e-2f1b6bfda50e": {
+      "connections": {
+        "outcome": "e1a7cb7b-4dae-4573-84f1-d19f4b4dcb03"
+      },
+      "displayName": "Password Collector",
+      "nodeType": "PasswordCollectorNode",
+      "x": 266,
+      "y": 295.015625
+    },
+    "e1a7cb7b-4dae-4573-84f1-d19f4b4dcb03": {
+      "connections": {
+        "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+        "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+      },
+      "displayName": "Data Store Decision",
+      "nodeType": "DataStoreDecisionNode",
+      "x": 510,
+      "y": 186.015625
+    },
+    "ee0efdc1-9fba-4323-95ef-ec468f6ad30c": {
+      "connections": {
+        "outcome": "4785b3c1-5dc9-4883-b01e-2f1b6bfda50e"
+      },
+      "displayName": "Username Collector",
+      "nodeType": "UsernameCollectorNode",
+      "x": 200,
+      "y": 218.015625
+    }
+  },
+  "staticNodes": {
+    "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+      "x": 809,
+      "y": 37
+    },
+    "e301438c-0bd0-429c-ab0c-66126501069a": {
+      "x": 823,
+      "y": 242
+    },
+    "startNode": {
+      "x": 50,
+      "y": 250
+    }
+  },
+  "enabled": true
+}

--- a/sapig-overlay/core/realms/alpha/journeys/PSD2 Secure Customer Authentication/nodes/Data Store Decision - e1a7cb7b-4dae-4573-84f1-d19f4b4dcb03.json
+++ b/sapig-overlay/core/realms/alpha/journeys/PSD2 Secure Customer Authentication/nodes/Data Store Decision - e1a7cb7b-4dae-4573-84f1-d19f4b4dcb03.json
@@ -1,0 +1,19 @@
+{
+  "_id": "e1a7cb7b-4dae-4573-84f1-d19f4b4dcb03",
+  "_rev": "836899399",
+  "_type": {
+    "_id": "DataStoreDecisionNode",
+    "name": "Data Store Decision",
+    "collection": true
+  },
+  "_outcomes": [
+    {
+      "id": "true",
+      "displayName": "True"
+    },
+    {
+      "id": "false",
+      "displayName": "False"
+    }
+  ]
+}

--- a/sapig-overlay/core/realms/alpha/journeys/PSD2 Secure Customer Authentication/nodes/Password Collector - 4785b3c1-5dc9-4883-b01e-2f1b6bfda50e.json
+++ b/sapig-overlay/core/realms/alpha/journeys/PSD2 Secure Customer Authentication/nodes/Password Collector - 4785b3c1-5dc9-4883-b01e-2f1b6bfda50e.json
@@ -1,0 +1,15 @@
+{
+  "_id": "4785b3c1-5dc9-4883-b01e-2f1b6bfda50e",
+  "_rev": "966344672",
+  "_type": {
+    "_id": "PasswordCollectorNode",
+    "name": "Password Collector",
+    "collection": true
+  },
+  "_outcomes": [
+    {
+      "id": "outcome",
+      "displayName": "Outcome"
+    }
+  ]
+}

--- a/sapig-overlay/core/realms/alpha/journeys/PSD2 Secure Customer Authentication/nodes/Username Collector - ee0efdc1-9fba-4323-95ef-ec468f6ad30c.json
+++ b/sapig-overlay/core/realms/alpha/journeys/PSD2 Secure Customer Authentication/nodes/Username Collector - ee0efdc1-9fba-4323-95ef-ec468f6ad30c.json
@@ -1,0 +1,15 @@
+{
+  "_id": "ee0efdc1-9fba-4323-95ef-ec468f6ad30c",
+  "_rev": "1640039686",
+  "_type": {
+    "_id": "UsernameCollectorNode",
+    "name": "Username Collector",
+    "collection": true
+  },
+  "_outcomes": [
+    {
+      "id": "outcome",
+      "displayName": "Outcome"
+    }
+  ]
+}

--- a/sapig-overlay/core/realms/alpha/journeys/PSD2CustomerAuthentication/PSD2CustomerAuthentication.json
+++ b/sapig-overlay/core/realms/alpha/journeys/PSD2CustomerAuthentication/PSD2CustomerAuthentication.json
@@ -1,0 +1,42 @@
+{
+  "_id": "PSD2CustomerAuthentication",
+  "_rev": "1208497051",
+  "uiConfig": {},
+  "entryNodeId": "9ea6a7ef-518a-4586-8f76-71865b1d0b18",
+  "nodes": {
+    "9ea6a7ef-518a-4586-8f76-71865b1d0b18": {
+      "x": 194,
+      "y": 253.015625,
+      "connections": {
+        "outcome": "f41f02b1-bb10-429d-8743-8c22d81898ac"
+      },
+      "nodeType": "PageNode",
+      "displayName": "Page Node"
+    },
+    "f41f02b1-bb10-429d-8743-8c22d81898ac": {
+      "x": 486,
+      "y": 242.015625,
+      "connections": {
+        "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+        "false": "e301438c-0bd0-429c-ab0c-66126501069a"
+      },
+      "nodeType": "DataStoreDecisionNode",
+      "displayName": "Data Store Decision"
+    }
+  },
+  "staticNodes": {
+    "startNode": {
+      "x": 50,
+      "y": 250
+    },
+    "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+      "x": 807,
+      "y": 157
+    },
+    "e301438c-0bd0-429c-ab0c-66126501069a": {
+      "x": 794,
+      "y": 307
+    }
+  },
+  "enabled": true
+}

--- a/sapig-overlay/core/realms/alpha/journeys/PSD2CustomerAuthentication/nodes/Data Store Decision - f41f02b1-bb10-429d-8743-8c22d81898ac.json
+++ b/sapig-overlay/core/realms/alpha/journeys/PSD2CustomerAuthentication/nodes/Data Store Decision - f41f02b1-bb10-429d-8743-8c22d81898ac.json
@@ -1,0 +1,19 @@
+{
+  "_id": "f41f02b1-bb10-429d-8743-8c22d81898ac",
+  "_rev": "-1744860878",
+  "_type": {
+    "_id": "DataStoreDecisionNode",
+    "name": "Data Store Decision",
+    "collection": true
+  },
+  "_outcomes": [
+    {
+      "id": "true",
+      "displayName": "True"
+    },
+    {
+      "id": "false",
+      "displayName": "False"
+    }
+  ]
+}

--- a/sapig-overlay/core/realms/alpha/journeys/PSD2CustomerAuthentication/nodes/Page Node - 9ea6a7ef-518a-4586-8f76-71865b1d0b18.json
+++ b/sapig-overlay/core/realms/alpha/journeys/PSD2CustomerAuthentication/nodes/Page Node - 9ea6a7ef-518a-4586-8f76-71865b1d0b18.json
@@ -1,0 +1,29 @@
+{
+  "_id": "9ea6a7ef-518a-4586-8f76-71865b1d0b18",
+  "_rev": "593125899",
+  "nodes": [
+    {
+      "_id": "ada9ef86-d550-4591-b9dc-5751e7adbb62",
+      "nodeType": "UsernameCollectorNode",
+      "displayName": "Username Collector"
+    },
+    {
+      "_id": "1db869b1-09de-4a8e-b340-e0563891c3bf",
+      "nodeType": "PasswordCollectorNode",
+      "displayName": "Password Collector"
+    }
+  ],
+  "pageDescription": {},
+  "pageHeader": {},
+  "_type": {
+    "_id": "PageNode",
+    "name": "Page Node",
+    "collection": true
+  },
+  "_outcomes": [
+    {
+      "id": "outcome",
+      "displayName": "Outcome"
+    }
+  ]
+}

--- a/sapig-overlay/core/realms/alpha/journeys/PSD2CustomerAuthentication/nodes/Page Node - 9ea6a7ef-518a-4586-8f76-71865b1d0b18/Password Collector - 1db869b1-09de-4a8e-b340-e0563891c3bf.json
+++ b/sapig-overlay/core/realms/alpha/journeys/PSD2CustomerAuthentication/nodes/Page Node - 9ea6a7ef-518a-4586-8f76-71865b1d0b18/Password Collector - 1db869b1-09de-4a8e-b340-e0563891c3bf.json
@@ -1,0 +1,15 @@
+{
+  "_id": "1db869b1-09de-4a8e-b340-e0563891c3bf",
+  "_rev": "1278861132",
+  "_type": {
+    "_id": "PasswordCollectorNode",
+    "name": "Password Collector",
+    "collection": true
+  },
+  "_outcomes": [
+    {
+      "id": "outcome",
+      "displayName": "Outcome"
+    }
+  ]
+}

--- a/sapig-overlay/core/realms/alpha/journeys/PSD2CustomerAuthentication/nodes/Page Node - 9ea6a7ef-518a-4586-8f76-71865b1d0b18/Username Collector - ada9ef86-d550-4591-b9dc-5751e7adbb62.json
+++ b/sapig-overlay/core/realms/alpha/journeys/PSD2CustomerAuthentication/nodes/Page Node - 9ea6a7ef-518a-4586-8f76-71865b1d0b18/Username Collector - ada9ef86-d550-4591-b9dc-5751e7adbb62.json
@@ -1,0 +1,15 @@
+{
+  "_id": "ada9ef86-d550-4591-b9dc-5751e7adbb62",
+  "_rev": "2111256055",
+  "_type": {
+    "_id": "UsernameCollectorNode",
+    "name": "Username Collector",
+    "collection": true
+  },
+  "_outcomes": [
+    {
+      "id": "outcome",
+      "displayName": "Outcome"
+    }
+  ]
+}

--- a/sapig-overlay/core/realms/alpha/journeys/PSD2SecureCustomerAuthentication/PSD2SecureCustomerAuthentication.json
+++ b/sapig-overlay/core/realms/alpha/journeys/PSD2SecureCustomerAuthentication/PSD2SecureCustomerAuthentication.json
@@ -1,0 +1,51 @@
+{
+  "_id": "PSD2SecureCustomerAuthentication",
+  "_rev": "-748957883",
+  "uiConfig": {},
+  "entryNodeId": "ee0efdc1-9fba-4323-95ef-ec468f6ad30c",
+  "nodes": {
+    "ee0efdc1-9fba-4323-95ef-ec468f6ad30c": {
+      "x": 200,
+      "y": 218.015625,
+      "connections": {
+        "outcome": "4785b3c1-5dc9-4883-b01e-2f1b6bfda50e"
+      },
+      "nodeType": "UsernameCollectorNode",
+      "displayName": "Username Collector"
+    },
+    "4785b3c1-5dc9-4883-b01e-2f1b6bfda50e": {
+      "x": 266,
+      "y": 295.015625,
+      "connections": {
+        "outcome": "e1a7cb7b-4dae-4573-84f1-d19f4b4dcb03"
+      },
+      "nodeType": "PasswordCollectorNode",
+      "displayName": "Password Collector"
+    },
+    "e1a7cb7b-4dae-4573-84f1-d19f4b4dcb03": {
+      "x": 510,
+      "y": 186.015625,
+      "connections": {
+        "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+        "false": "e301438c-0bd0-429c-ab0c-66126501069a"
+      },
+      "nodeType": "DataStoreDecisionNode",
+      "displayName": "Data Store Decision"
+    }
+  },
+  "staticNodes": {
+    "startNode": {
+      "x": 50,
+      "y": 250
+    },
+    "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+      "x": 809,
+      "y": 37
+    },
+    "e301438c-0bd0-429c-ab0c-66126501069a": {
+      "x": 823,
+      "y": 242
+    }
+  },
+  "enabled": true
+}

--- a/sapig-overlay/core/realms/alpha/journeys/PSD2SecureCustomerAuthentication/nodes/Data Store Decision - e1a7cb7b-4dae-4573-84f1-d19f4b4dcb03.json
+++ b/sapig-overlay/core/realms/alpha/journeys/PSD2SecureCustomerAuthentication/nodes/Data Store Decision - e1a7cb7b-4dae-4573-84f1-d19f4b4dcb03.json
@@ -1,0 +1,19 @@
+{
+  "_id": "e1a7cb7b-4dae-4573-84f1-d19f4b4dcb03",
+  "_rev": "836899399",
+  "_type": {
+    "_id": "DataStoreDecisionNode",
+    "name": "Data Store Decision",
+    "collection": true
+  },
+  "_outcomes": [
+    {
+      "id": "true",
+      "displayName": "True"
+    },
+    {
+      "id": "false",
+      "displayName": "False"
+    }
+  ]
+}

--- a/sapig-overlay/core/realms/alpha/journeys/PSD2SecureCustomerAuthentication/nodes/Password Collector - 4785b3c1-5dc9-4883-b01e-2f1b6bfda50e.json
+++ b/sapig-overlay/core/realms/alpha/journeys/PSD2SecureCustomerAuthentication/nodes/Password Collector - 4785b3c1-5dc9-4883-b01e-2f1b6bfda50e.json
@@ -1,0 +1,15 @@
+{
+  "_id": "4785b3c1-5dc9-4883-b01e-2f1b6bfda50e",
+  "_rev": "966344672",
+  "_type": {
+    "_id": "PasswordCollectorNode",
+    "name": "Password Collector",
+    "collection": true
+  },
+  "_outcomes": [
+    {
+      "id": "outcome",
+      "displayName": "Outcome"
+    }
+  ]
+}

--- a/sapig-overlay/core/realms/alpha/journeys/PSD2SecureCustomerAuthentication/nodes/Username Collector - ee0efdc1-9fba-4323-95ef-ec468f6ad30c.json
+++ b/sapig-overlay/core/realms/alpha/journeys/PSD2SecureCustomerAuthentication/nodes/Username Collector - ee0efdc1-9fba-4323-95ef-ec468f6ad30c.json
@@ -1,0 +1,15 @@
+{
+  "_id": "ee0efdc1-9fba-4323-95ef-ec468f6ad30c",
+  "_rev": "1640039686",
+  "_type": {
+    "_id": "UsernameCollectorNode",
+    "name": "Username Collector",
+    "collection": true
+  },
+  "_outcomes": [
+    {
+      "id": "outcome",
+      "displayName": "Outcome"
+    }
+  ]
+}

--- a/sapig-overlay/core/realms/alpha/realm-config/agents/IdentityGatewayAgent/ig-agent.json
+++ b/sapig-overlay/core/realms/alpha/realm-config/agents/IdentityGatewayAgent/ig-agent.json
@@ -1,0 +1,14 @@
+{
+  "_id": "ig-agent",
+  "_rev": "1394611646",
+  "userpassword": "&{esv.ig.agent.password}",
+  "igTokenIntrospection": {
+    "inherited": false,
+    "value": "Realm"
+  },
+  "_type": {
+    "_id": "IdentityGatewayAgent",
+    "name": "Identity Gateway Agents",
+    "collection": true
+  }
+}

--- a/sapig-overlay/core/realms/alpha/realm-config/agents/OAuth2Client/ig-client.json
+++ b/sapig-overlay/core/realms/alpha/realm-config/agents/OAuth2Client/ig-client.json
@@ -1,0 +1,43 @@
+{
+  "_id": "ig-client",
+  "_rev": "1070432342",
+  "coreOAuth2ClientConfig": {
+    "userpassword": "&{esv.ig.client.password}",
+    "scopes": {
+      "inherited": false,
+      "value": [
+        "fr:idm:*",
+        "dynamic_client_registration",
+        "trusted_gateway"
+      ]
+    },
+    "clientType": {
+      "inherited": false,
+      "value": "Confidential"
+    },
+    "redirectionUris": {
+      "inherited": false,
+      "value": [
+        "https://httpbin.org/anything"
+      ]
+    },
+    "status": {
+      "inherited": false,
+      "value": "Active"
+    }
+  },
+  "advancedOAuth2ClientConfig": {
+    "grantTypes": {
+      "inherited": false,
+      "value": [
+        "client_credentials",
+        "password"
+      ]
+    }
+  },
+  "_type": {
+    "_id": "OAuth2Client",
+    "name": "OAuth2 Clients",
+    "collection": true
+  }
+}

--- a/sapig-overlay/core/realms/alpha/realm-config/agents/SoftwarePublisher/Secure API Gateway Development Trusted Directory.json
+++ b/sapig-overlay/core/realms/alpha/realm-config/agents/SoftwarePublisher/Secure API Gateway Development Trusted Directory.json
@@ -1,0 +1,37 @@
+{
+  "_id": "Secure API Gateway Development Trusted Directory",
+  "_rev": "-991743971",
+  "userpassword": null,
+  "publicKeyLocation": {
+    "inherited": false,
+    "value": "jwks_uri"
+  },
+  "jwksCacheTimeout": {
+    "inherited": false,
+    "value": 3600000
+  },
+  "softwareStatementSigningAlgorithm": {
+    "inherited": false,
+    "value": "PS256"
+  },
+  "jwkSet": {
+    "inherited": false
+  },
+  "issuer": {
+    "inherited": false,
+    "value": "test-publisher"
+  },
+  "jwkStoreCacheMissCacheTime": {
+    "inherited": false,
+    "value": 60000
+  },
+  "jwksUri": {
+    "inherited": false,
+    "value": "&{esv.baseurl}/jwkms/testdirectory/jwks"
+  },
+  "_type": {
+    "_id": "SoftwarePublisher",
+    "name": "OAuth2 Software Publisher",
+    "collection": true
+  }
+}

--- a/sapig-overlay/core/realms/alpha/realm-config/authentication.json
+++ b/sapig-overlay/core/realms/alpha/realm-config/authentication.json
@@ -1,0 +1,67 @@
+{
+  "_id": "",
+  "_rev": "-1957641651",
+  "security": {
+    "zeroPageLoginEnabled": false,
+    "zeroPageLoginReferrerWhiteList": [],
+    "zeroPageLoginAllowedWithoutReferrer": true,
+    "moduleBasedAuthEnabled": false,
+    "sharedSecret": {
+      "$string": "&{am.authentication.shared.secret}"
+    },
+    "keyAlias": "test"
+  },
+  "postauthprocess": {
+    "usernameGeneratorClass": "com.sun.identity.authentication.spi.DefaultUserIDGenerator",
+    "usernameGeneratorEnabled": true,
+    "loginPostProcessClass": [],
+    "loginSuccessUrl": [
+      "/enduser/?realm=/alpha"
+    ],
+    "userAttributeSessionMapping": [],
+    "loginFailureUrl": []
+  },
+  "trees": {
+    "suspendedAuthenticationTimeout": 1440,
+    "authenticationSessionsStateManagement": "JWT",
+    "authenticationSessionsMaxDuration": 5,
+    "authenticationTreeCookieHttpOnly": true,
+    "authenticationSessionsWhitelist": false
+  },
+  "accountlockout": {
+    "loginFailureLockoutMode": false,
+    "storeInvalidAttemptsInDataStore": true,
+    "lockoutDuration": 0,
+    "lockoutDurationMultiplier": 1,
+    "lockoutWarnUserCount": 0,
+    "loginFailureCount": 5,
+    "loginFailureDuration": 300
+  },
+  "general": {
+    "userStatusCallbackPlugins": [],
+    "statelessSessionsEnabled": false,
+    "locale": "en_US",
+    "twoFactorRequired": false,
+    "identityType": [
+      "agent",
+      "user"
+    ],
+    "defaultAuthLevel": 0
+  },
+  "core": {
+    "adminAuthModule": "[Empty]",
+    "orgConfig": "Login"
+  },
+  "userprofile": {
+    "dynamicProfileCreation": "false",
+    "defaultRole": [],
+    "aliasAttributeName": [
+      "uid"
+    ]
+  },
+  "_type": {
+    "_id": "EMPTY",
+    "name": "Core",
+    "collection": false
+  }
+}

--- a/sapig-overlay/core/realms/alpha/secret-mappings/am.services.oauth2.tls.client.cert.authentication.json
+++ b/sapig-overlay/core/realms/alpha/secret-mappings/am.services.oauth2.tls.client.cert.authentication.json
@@ -1,0 +1,13 @@
+{
+  "_id": "am.services.oauth2.tls.client.cert.authentication",
+  "_rev": "1978122296",
+  "secretId": "am.services.oauth2.tls.client.cert.authentication",
+  "aliases": [
+    "esv-am-oauth2-ca-certs"
+  ],
+  "_type": {
+    "_id": "mappings",
+    "name": "Mappings",
+    "collection": true
+  }
+}

--- a/sapig-overlay/core/realms/alpha/services/baseurl.json
+++ b/sapig-overlay/core/realms/alpha/services/baseurl.json
@@ -1,0 +1,12 @@
+{
+  "_id": "",
+  "_rev": "800394109",
+  "source": "FIXED_VALUE",
+  "fixedValue": "&{esv.baseurl}",
+  "contextPath": "/am",
+  "_type": {
+    "_id": "baseurl",
+    "name": "Base URL Source",
+    "collection": false
+  }
+}

--- a/sapig-overlay/core/realms/alpha/services/oauth-oidc.json
+++ b/sapig-overlay/core/realms/alpha/services/oauth-oidc.json
@@ -1,0 +1,320 @@
+{
+  "_id": "",
+  "_rev": "1031866848",
+  "advancedOIDCConfig": {
+    "supportedRequestParameterEncryptionEnc": [
+      "A256GCM",
+      "A192GCM",
+      "A128GCM",
+      "A128CBC-HS256",
+      "A192CBC-HS384",
+      "A256CBC-HS512"
+    ],
+    "authorisedOpenIdConnectSSOClients": [],
+    "supportedUserInfoEncryptionAlgorithms": [
+      "ECDH-ES+A256KW",
+      "ECDH-ES+A192KW",
+      "RSA-OAEP",
+      "ECDH-ES+A128KW",
+      "RSA-OAEP-256",
+      "A128KW",
+      "A256KW",
+      "ECDH-ES",
+      "dir",
+      "A192KW"
+    ],
+    "supportedAuthorizationResponseEncryptionEnc": [
+      "A256GCM",
+      "A192GCM",
+      "A128GCM",
+      "A128CBC-HS256",
+      "A192CBC-HS384",
+      "A256CBC-HS512"
+    ],
+    "supportedTokenIntrospectionResponseEncryptionAlgorithms": [
+      "ECDH-ES+A256KW",
+      "ECDH-ES+A192KW",
+      "RSA-OAEP",
+      "ECDH-ES+A128KW",
+      "RSA-OAEP-256",
+      "A128KW",
+      "A256KW",
+      "ECDH-ES",
+      "dir",
+      "A192KW"
+    ],
+    "useForceAuthnForPromptLogin": false,
+    "alwaysAddClaimsToToken": true,
+    "supportedTokenIntrospectionResponseSigningAlgorithms": [
+      "PS256"
+    ],
+    "supportedTokenEndpointAuthenticationSigningAlgorithms": [
+      "PS256"
+    ],
+    "supportedRequestParameterSigningAlgorithms": [
+      "PS256"
+    ],
+    "includeAllKtyAlgCombinationsInJwksUri": false,
+    "amrMappings": {},
+    "loaMapping": {
+      "urn:mace:incommon:iap:silver": "PSD2CustomerAuthentication"
+    },
+    "authorisedIdmDelegationClients": [],
+    "idTokenInfoClientAuthenticationEnabled": true,
+    "storeOpsTokens": true,
+    "supportedUserInfoSigningAlgorithms": [
+      "PS256"
+    ],
+    "supportedAuthorizationResponseSigningAlgorithms": [
+      "PS256"
+    ],
+    "supportedUserInfoEncryptionEnc": [
+      "A256GCM",
+      "A192GCM",
+      "A128GCM",
+      "A128CBC-HS256",
+      "A192CBC-HS384",
+      "A256CBC-HS512"
+    ],
+    "claimsParameterSupported": true,
+    "supportedTokenIntrospectionResponseEncryptionEnc": [
+      "A256GCM",
+      "A192GCM",
+      "A128GCM",
+      "A128CBC-HS256",
+      "A192CBC-HS384",
+      "A256CBC-HS512"
+    ],
+    "supportedAuthorizationResponseEncryptionAlgorithms": [
+      "ECDH-ES+A256KW",
+      "ECDH-ES+A192KW",
+      "RSA-OAEP",
+      "ECDH-ES+A128KW",
+      "RSA-OAEP-256",
+      "A128KW",
+      "A256KW",
+      "ECDH-ES",
+      "dir",
+      "A192KW"
+    ],
+    "supportedRequestParameterEncryptionAlgorithms": [
+      "ECDH-ES+A256KW",
+      "ECDH-ES+A192KW",
+      "ECDH-ES+A128KW",
+      "RSA-OAEP",
+      "RSA-OAEP-256",
+      "A128KW",
+      "A256KW",
+      "ECDH-ES",
+      "dir",
+      "A192KW"
+    ],
+    "defaultACR": []
+  },
+  "advancedOAuth2Config": {
+    "tokenCompressionEnabled": false,
+    "tokenEncryptionEnabled": false,
+    "requirePushedAuthorizationRequests": false,
+    "tlsCertificateBoundAccessTokensEnabled": true,
+    "defaultScopes": [],
+    "moduleMessageEnabledInPasswordGrant": false,
+    "supportedSubjectTypes": [
+      "public",
+      "pairwise"
+    ],
+    "refreshTokenGracePeriod": 0,
+    "tlsClientCertificateHeaderFormat": "URLENCODED_PEM",
+    "hashSalt": "&{am.oidc.client.subject.identifier.hash.salt}",
+    "macaroonTokenFormat": "V2",
+    "maxAgeOfRequestObjectNbfClaim": 0,
+    "tlsCertificateRevocationCheckingEnabled": false,
+    "nbfClaimRequiredInRequestObject": true,
+    "requestObjectProcessing": "OIDC",
+    "maxDifferenceBetweenRequestObjectNbfAndExp": 60,
+    "responseTypeClasses": [
+      "code|org.forgerock.oauth2.core.AuthorizationCodeResponseTypeHandler",
+      "id_token|org.forgerock.openidconnect.IdTokenResponseTypeHandler"
+    ],
+    "expClaimRequiredInRequestObject": true,
+    "tokenValidatorClasses": [
+      "urn:ietf:params:oauth:token-type:id_token|org.forgerock.oauth2.core.tokenexchange.idtoken.OidcIdTokenValidator",
+      "urn:ietf:params:oauth:token-type:access_token|org.forgerock.oauth2.core.tokenexchange.accesstoken.OAuth2AccessTokenValidator"
+    ],
+    "tokenSigningAlgorithm": "PS256",
+    "codeVerifierEnforced": "false",
+    "displayNameAttribute": "cn",
+    "tokenExchangeClasses": [
+      "urn:ietf:params:oauth:token-type:access_token=>urn:ietf:params:oauth:token-type:access_token|org.forgerock.oauth2.core.tokenexchange.accesstoken.AccessTokenToAccessTokenExchanger",
+      "urn:ietf:params:oauth:token-type:id_token=>urn:ietf:params:oauth:token-type:id_token|org.forgerock.oauth2.core.tokenexchange.idtoken.IdTokenToIdTokenExchanger",
+      "urn:ietf:params:oauth:token-type:access_token=>urn:ietf:params:oauth:token-type:id_token|org.forgerock.oauth2.core.tokenexchange.accesstoken.AccessTokenToIdTokenExchanger",
+      "urn:ietf:params:oauth:token-type:id_token=>urn:ietf:params:oauth:token-type:access_token|org.forgerock.oauth2.core.tokenexchange.idtoken.IdTokenToAccessTokenExchanger"
+    ],
+    "parRequestUriLifetime": 90,
+    "allowedAudienceValues": [
+      "&{esv.baseurl}/am/oauth2/realms/root/realms/&{esv.sapig.identity.cloud.realm}/access_token",
+      "&{esv.mtls.baseurl}/am/oauth2/realms/root/realms/&{esv.sapig.identity.cloud.realm}/access_token"
+    ],
+    "persistentClaims": [],
+    "supportedScopes": [
+      "openid",
+      "payments",
+      "accounts",
+      "eventpolling",
+      "fundsconfirmations"
+    ],
+    "authenticationAttributes": [
+      "uid"
+    ],
+    "grantTypes": [
+      "implicit",
+      "urn:ietf:params:oauth:grant-type:saml2-bearer",
+      "refresh_token",
+      "password",
+      "client_credentials",
+      "urn:ietf:params:oauth:grant-type:device_code",
+      "authorization_code",
+      "urn:openid:params:grant-type:ciba",
+      "urn:ietf:params:oauth:grant-type:uma-ticket",
+      "urn:ietf:params:oauth:grant-type:jwt-bearer"
+    ],
+    "tlsClientCertificateTrustedHeader": "ssl-client-cert"
+  },
+  "clientDynamicRegistrationConfig": {
+    "dynamicClientRegistrationScope": "dynamic_client_registration",
+    "allowDynamicRegistration": false,
+    "requiredSoftwareStatementAttestedAttributes": [],
+    "dynamicClientRegistrationSoftwareStatementRequired": true,
+    "generateRegistrationAccessTokens": true
+  },
+  "coreOIDCConfig": {
+    "overrideableOIDCClaims": [],
+    "oidcDiscoveryEndpointEnabled": true,
+    "supportedIDTokenEncryptionMethods": [
+      "A256GCM",
+      "A192GCM",
+      "A128GCM",
+      "A128CBC-HS256",
+      "A192CBC-HS384",
+      "A256CBC-HS512"
+    ],
+    "supportedClaims": [
+      "acr"
+    ],
+    "supportedIDTokenSigningAlgorithms": [
+      "PS256"
+    ],
+    "supportedIDTokenEncryptionAlgorithms": [
+      "ECDH-ES+A256KW",
+      "ECDH-ES+A192KW",
+      "RSA-OAEP",
+      "ECDH-ES+A128KW",
+      "RSA-OAEP-256",
+      "A128KW",
+      "A256KW",
+      "ECDH-ES",
+      "dir",
+      "A192KW"
+    ],
+    "jwtTokenLifetime": 3600
+  },
+  "coreOAuth2Config": {
+    "refreshTokenLifetime": 604800,
+    "scopesPolicySet": "oauth2Scopes",
+    "accessTokenMayActScript": "[Empty]",
+    "accessTokenLifetime": 360000,
+    "macaroonTokensEnabled": false,
+    "codeLifetime": 120,
+    "statelessTokensEnabled": true,
+    "usePolicyEngineForScope": false,
+    "issueRefreshToken": true,
+    "oidcMayActScript": "[Empty]",
+    "issueRefreshTokenOnRefreshedToken": true
+  },
+  "consent": {
+    "supportedRcsRequestSigningAlgorithms": [
+      "PS256"
+    ],
+    "supportedRcsResponseEncryptionAlgorithms": [
+      "ECDH-ES+A256KW",
+      "ECDH-ES+A192KW",
+      "ECDH-ES+A128KW",
+      "RSA-OAEP",
+      "RSA-OAEP-256",
+      "A128KW",
+      "A256KW",
+      "ECDH-ES",
+      "dir",
+      "A192KW"
+    ],
+    "supportedRcsRequestEncryptionMethods": [
+      "A256GCM",
+      "A192GCM",
+      "A128GCM",
+      "A128CBC-HS256",
+      "A192CBC-HS384",
+      "A256CBC-HS512"
+    ],
+    "enableRemoteConsent": false,
+    "supportedRcsRequestEncryptionAlgorithms": [
+      "ECDH-ES+A256KW",
+      "ECDH-ES+A192KW",
+      "RSA-OAEP",
+      "ECDH-ES+A128KW",
+      "RSA-OAEP-256",
+      "A128KW",
+      "A256KW",
+      "ECDH-ES",
+      "dir",
+      "A192KW"
+    ],
+    "clientsCanSkipConsent": false,
+    "supportedRcsResponseSigningAlgorithms": [
+      "PS256"
+    ],
+    "supportedRcsResponseEncryptionMethods": [
+      "A256GCM",
+      "A192GCM",
+      "A128GCM",
+      "A128CBC-HS256",
+      "A192CBC-HS384",
+      "A256CBC-HS512"
+    ]
+  },
+  "deviceCodeConfig": {
+    "deviceUserCodeLength": 8,
+    "deviceCodeLifetime": 300,
+    "deviceUserCodeCharacterSet": "234567ACDEFGHJKLMNPQRSTWXYZabcdefhijkmnopqrstwxyz",
+    "devicePollInterval": 5
+  },
+  "pluginsConfig": {
+    "evaluateScopeClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
+    "validateScopeScript": "[Empty]",
+    "accessTokenEnricherClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
+    "oidcClaimsPluginType": "SCRIPTED",
+    "authorizeEndpointDataProviderClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
+    "authorizeEndpointDataProviderPluginType": "JAVA",
+    "userCodeGeneratorClass": "org.forgerock.oauth2.core.plugins.registry.DefaultUserCodeGenerator",
+    "evaluateScopeScript": "[Empty]",
+    "oidcClaimsClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
+    "evaluateScopePluginType": "JAVA",
+    "authorizeEndpointDataProviderScript": "[Empty]",
+    "accessTokenModifierClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
+    "accessTokenModificationScript": "39c08084-1238-43e8-857f-2e11005eac49",
+    "validateScopePluginType": "JAVA",
+    "accessTokenModificationPluginType": "SCRIPTED",
+    "oidcClaimsScript": "cf3515f0-8278-4ee3-a530-1bad7424c416",
+    "validateScopeClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator"
+  },
+  "cibaConfig": {
+    "cibaMinimumPollingInterval": 2,
+    "supportedCibaSigningAlgorithms": [
+      "PS256"
+    ],
+    "cibaAuthReqIdLifetime": 600
+  },
+  "_type": {
+    "_id": "oauth-oidc",
+    "name": "OAuth2 Provider",
+    "collection": false
+  }
+}

--- a/sapig-overlay/core/realms/alpha/services/validation.json
+++ b/sapig-overlay/core/realms/alpha/services/validation.json
@@ -1,0 +1,13 @@
+{
+  "_id": "",
+  "_rev": "-1211374045",
+  "validGotoDestinations": [
+    "&{am.server.protocol|https}://&{fqdn}/*?*",
+    "&{esv.baseurl}/am/*?*"
+  ],
+  "_type": {
+    "_id": "validation",
+    "name": "Validation Service",
+    "collection": false
+  }
+}

--- a/sapig-overlay/core/service-objects/alpha_user/service_account.ig.json
+++ b/sapig-overlay/core/service-objects/alpha_user/service_account.ig.json
@@ -1,0 +1,20 @@
+{
+  "_id": "ff527a65-1719-45b8-aaf2-90683595a5a7",
+  "_rev": "5abb7ad0-325b-4898-8dd4-192993fe408f-16959",
+  "authzRoles": [
+    {
+      "_ref": "internal/role/openidm-admin",
+      "_refProperties": {
+        "_id": "537fda8f-4fee-446b-8085-6f3e67a48855",
+        "_rev": "5abb7ad0-325b-4898-8dd4-192993fe408f-16958"
+      },
+      "_refResourceCollection": "internal/role",
+      "_refResourceId": "openidm-admin"
+    }
+  ],
+  "givenName": "IG",
+  "mail": "obst@forgerock.com",
+  "password": "${ESV_IG_IDM_ADMIN_PASSWORD_1}",
+  "sn": "Service Account",
+  "userName": "service_account.ig"
+}


### PR DESCRIPTION
This config supports the FAPI 1.0 Part 2 Advanced "plain_fapi" profile deployment of SAPI-G core.

The config has been created using the OB config as a starting point and removing OB specific references from it.

Key changes:
- RCS support removed
- OB specific ACR values removed
- plain_fapi acr: `urn:mace:incommon:iap:silver` added
- OB Software Publisher removed
- `openbanking_intent_id` removed from supported claims

Note: This config is currently untested, a cloud instance for use by SAPI-G core is required first.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1300