### PR TITLE
1345: Remove use of jwksproxy from Open Banking Test Directory Software Publisher

### DIFF
--- a/sapig-overlay/ob/realms/alpha/realm-config/agents/SoftwarePublisher/Open Banking Test Directory.json
+++ b/sapig-overlay/ob/realms/alpha/realm-config/agents/SoftwarePublisher/Open Banking Test Directory.json
@@ -26,7 +26,7 @@
   },
   "jwksUri": {
     "inherited": false,
-    "value": "&{esv.baseurl}/jwkms/jwksproxy/keystore.openbankingtest.org.uk/keystore/openbanking.jwks"
+    "value": "https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks"
   },
   "_type": {
     "_id": "SoftwarePublisher",


### PR DESCRIPTION
Open Banking Test Directory Software Publisher is now configured to access the Open Banking Test Directory jwks_uri directly as we expect the AM truststore to be configured correctly.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1345