### PR TITLE
1338: Adding Open Banking Test Directory Software Publisher config for SAPI-G

### DIFF
--- a/sapig-overlay/core/realms/alpha/realm-config/agents/SoftwarePublisher/Open Banking Test Directory.json
+++ b/sapig-overlay/core/realms/alpha/realm-config/agents/SoftwarePublisher/Open Banking Test Directory.json
@@ -1,0 +1,36 @@
+{
+  "_id": "Open Banking Test Directory",
+  "_rev": "-516262382",
+  "publicKeyLocation": {
+    "inherited": false,
+    "value": "jwks_uri"
+  },
+  "jwksCacheTimeout": {
+    "inherited": false,
+    "value": 3600000
+  },
+  "softwareStatementSigningAlgorithm": {
+    "inherited": false,
+    "value": "PS256"
+  },
+  "jwkSet": {
+    "inherited": false
+  },
+  "issuer": {
+    "inherited": false,
+    "value": "OpenBanking Ltd"
+  },
+  "jwkStoreCacheMissCacheTime": {
+    "inherited": false,
+    "value": 60000
+  },
+  "jwksUri": {
+    "inherited": false,
+    "value": "https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks"
+  },
+  "_type": {
+    "_id": "SoftwarePublisher",
+    "name": "OAuth2 Software Publisher",
+    "collection": true
+  }
+}


### PR DESCRIPTION
Supporting OB DCRs in SAPI-G core.

OB issued SSAs and certs are easier to configure and test with (especially in the OIDF conformance suite).

https://github.com/SecureApiGateway/SecureApiGateway/issues/1338