### PR TITLE
1300: Reverting change to the cors ESV as it is shared across a tenant

### DIFF
--- a/sapig-overlay/core/.env.sample
+++ b/sapig-overlay/core/.env.sample
@@ -45,8 +45,10 @@ OAUTH2_AGENTS='{
 
 #ESV_CORE_BASEURL=
 #ESV_CORE_MTLS_BASEURL=
-#ESV_CORE_CORS_ACCEPTED_ORIGINS=
 #ESV_CORE_SAPIG_IDENTITY_CLOUD_REALM=
+
+# NOTE: cors conf applies to the whole tenant and not just a realm
+#ESV_CORS_ACCEPTED_ORIGINS=
 
 # ESV Secrets - the below values need to be supplied when doing fr-config-push secrets
 #ESV_CORE_AM_OAUTH2_CA_CERTS_1=

--- a/sapig-overlay/core/cors/cors-config.json
+++ b/sapig-overlay/core/cors/cors-config.json
@@ -56,7 +56,7 @@
         "OPTIONS"
       ],
       "acceptedOrigins": {
-        "$list": "&{esv.sapig.core.cors.accepted.origins}"
+        "$list": "&{esv.cors.accepted.origins}"
       },
       "allowCredentials": true,
       "enabled": true,

--- a/sapig-overlay/core/esvs/variables/esv-cors-accepted-origins.json
+++ b/sapig-overlay/core/esvs/variables/esv-cors-accepted-origins.json
@@ -1,0 +1,6 @@
+{
+  "_id": "esv-cors-accepted-origins",
+  "description": "",
+  "expressionType": "list",
+  "valueBase64": "${ESV_CORS_ACCEPTED_ORIGINS}"
+}

--- a/sapig-overlay/core/esvs/variables/esv-sapig-core-cors-accepted-origins.json
+++ b/sapig-overlay/core/esvs/variables/esv-sapig-core-cors-accepted-origins.json
@@ -1,6 +1,0 @@
-{
-  "_id": "esv-sapig-core-cors-accepted-origins",
-  "description": "",
-  "expressionType": "list",
-  "valueBase64": "${ESV_SAPIG_CORE_CORS_ACCEPTED_ORIGINS}"
-}

--- a/sapig-overlay/ob/.env.sample
+++ b/sapig-overlay/ob/.env.sample
@@ -46,8 +46,10 @@ OAUTH2_AGENTS='{
 
 #ESV_OB_BASEURL=
 #ESV_OB_MTLS_BASEURL=
-#ESV_OB_CORS_ACCEPTED_ORIGINS=
 #ESV_OB_SAPIG_IDENTITY_CLOUD_REALM=
+
+# NOTE: cors conf applies to the whole tenant and not just a realm
+#ESV_CORS_ACCEPTED_ORIGINS=
 
 # ESV Secrets - the below values need to be supplied when doing fr-config-push secrets
 #ESV_OB_AM_OAUTH2_CA_CERTS_1=

--- a/sapig-overlay/ob/cors/cors-config.json
+++ b/sapig-overlay/ob/cors/cors-config.json
@@ -56,7 +56,7 @@
         "OPTIONS"
       ],
       "acceptedOrigins": {
-        "$list": "&{esv.sapig.ob.cors.accepted.origins}"
+        "$list": "&{esv.cors.accepted.origins}"
       },
       "allowCredentials": true,
       "enabled": true,

--- a/sapig-overlay/ob/esvs/variables/esv-cors-accepted-origins.json
+++ b/sapig-overlay/ob/esvs/variables/esv-cors-accepted-origins.json
@@ -1,0 +1,6 @@
+{
+  "_id": "esv-cors-accepted-origins",
+  "description": "",
+  "expressionType": "list",
+  "valueBase64": "${ESV_CORS_ACCEPTED_ORIGINS}"
+}

--- a/sapig-overlay/ob/esvs/variables/esv-sapig-ob-cors-accepted-origins.json
+++ b/sapig-overlay/ob/esvs/variables/esv-sapig-ob-cors-accepted-origins.json
@@ -1,6 +1,0 @@
-{
-  "_id": "esv-sapig-ob-cors-accepted-origins",
-  "description": "",
-  "expressionType": "list",
-  "valueBase64": "${ESV_SAPIG_OB_CORS_ACCEPTED_ORIGINS}"
-}


### PR DESCRIPTION
Reverting cors ESV name to `esv-cors-accepted-origins`

This configuration applies to the tenant as a whole, if the tenant needs to support multiple realms then the value of `esv-cors-accepted-origins` needs to be a list containing all the accepted origins for both realms.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1300