### PR TITLE
1551: allow PAR endpoint as aud value in client assertion JWT

### DIFF
--- a/sapig-overlay/core/realms/realmName/services/oauth-oidc.json
+++ b/sapig-overlay/core/realms/realmName/services/oauth-oidc.json
@@ -9,7 +9,8 @@
   "advancedOAuth2Config": {
     "allowedAudienceValues": [
       "&{esv.sapig.core.baseurl}/am/oauth2/realms/root/realms/&{esv.sapig.core.identity.cloud.realm}/access_token",
-      "&{esv.sapig.core.mtls.baseurl}/am/oauth2/realms/root/realms/&{esv.sapig.core.identity.cloud.realm}/access_token"
+      "&{esv.sapig.core.mtls.baseurl}/am/oauth2/realms/root/realms/&{esv.sapig.core.identity.cloud.realm}/access_token",
+      "&{esv.sapig.core.mtls.baseurl}/am/oauth2/realms/root/realms/&{esv.sapig.core.identity.cloud.realm}/par"
     ],
     "authenticationAttributes": [
       "uid"


### PR DESCRIPTION
The PAR specification states that the PAR endpoint should be accepted as a valid iss claim in a client assertion JWT. This commit adds the PAR endpoint to the OAuth2Provider's list of acceptable iss values.

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1551