### PR TITLE
1529: Rename ApiClient.id field to softwareId

### DIFF
--- a/sapig-overlay/core/managed-objects/apiClient/apiClient.json
+++ b/sapig-overlay/core/managed-objects/apiClient/apiClient.json
@@ -8,7 +8,7 @@
     "mat-icon": null,
     "order": [
       "_id",
-      "id",
+      "softwareId",
       "name",
       "description",
       "deleted",
@@ -94,12 +94,12 @@
         "userEditable": true,
         "viewable": true
       },
-      "id": {
+      "softwareId": {
         "deleteQueryConfig": false,
         "description": null,
         "isVirtual": false,
         "searchable": true,
-        "title": "API Client ID",
+        "title": "Software ID",
         "type": "string",
         "userEditable": true,
         "viewable": true
@@ -164,7 +164,7 @@
       }
     },
     "required": [
-      "id",
+      "softwareId",
       "name",
       "oauth2ClientId",
       "ssa",


### PR DESCRIPTION
This is a breaking schema change and should only be used in new environments.

Environments with existing data needs to make this change by following the steps in this PR: https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-fidc-initializer/pull/253 to prevent breaking existing ApiClients.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1529