### PR TITLE
1529: Rename ApiClient.id field to softwareId

### DIFF
--- a/sapig-overlay/core/managed-objects/apiClient/apiClient.json
+++ b/sapig-overlay/core/managed-objects/apiClient/apiClient.json
@@ -1,6 +1,11 @@
 {
   "iconClass": "fa fa-database",
   "name": "apiClient",
+  "onRead": {
+    "type": "text/javascript",
+    "globals": {},
+    "source": "if (object.softwareId == null) {\n  object.softwareId = object.id\n}"
+  },
   "schema": {
     "$schema": "http://forgerock.org/json-schema#",
     "description": "Secure Banking apiClient",
@@ -8,7 +13,7 @@
     "mat-icon": null,
     "order": [
       "_id",
-      "id",
+      "softwareId",
       "name",
       "description",
       "deleted",
@@ -104,6 +109,16 @@
         "userEditable": true,
         "viewable": true
       },
+      "softwareId": {
+        "deleteQueryConfig": false,
+        "description": null,
+        "isVirtual": false,
+        "searchable": true,
+        "title": "Software ID",
+        "type": "string",
+        "userEditable": true,
+        "viewable": true
+      },
       "jwks": {
         "searchable": false,
         "title": "JWK Set",
@@ -164,7 +179,6 @@
       }
     },
     "required": [
-      "id",
       "name",
       "oauth2ClientId",
       "ssa",


### PR DESCRIPTION
The ApiClient.id field is confusing, it is not the unique id of an ApiClient object, the _id field should be used for this purpose.

The field actually represents the softwareId (which is not unique, multiple clients may be registered for the same piece of software).

In this change we are "renaming" the id field in a non-breaking fashion by doing the following:
- Adding new field: softwareId which is optional
- Making the existing id field optional.
- Adding an onRead script which defaults the softwareId field to the id value

Using the script prevents this from being a breaking change by providing a default value for the softwareId.

This change can be applied prior to deploying a code change that uses the softwareId field.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1529