### PR TITLE
OPENIG-10737 Fix stale jwksUri path for sample-trusted-directory migration

### DIFF
--- a/sapig-overlay/core/realms/realmName/realm-config/agents/SoftwarePublisher/Secure API Gateway Development Trusted Directory.json
+++ b/sapig-overlay/core/realms/realmName/realm-config/agents/SoftwarePublisher/Secure API Gateway Development Trusted Directory.json
@@ -23,7 +23,7 @@
   },
   "jwksUri": {
     "inherited": false,
-    "value": "&{esv.sapig.core.trusteddirurl}/jwkms/testdirectory/jwks"
+    "value": "&{esv.sapig.core.trusteddirurl}/api/directory/jwks"
   },
   "publicKeyLocation": {
     "inherited": false,

--- a/sapig-overlay/ob/realms/realmName/realm-config/agents/SoftwarePublisher/Secure API Gateway Development Trusted Directory.json
+++ b/sapig-overlay/ob/realms/realmName/realm-config/agents/SoftwarePublisher/Secure API Gateway Development Trusted Directory.json
@@ -23,7 +23,7 @@
   },
   "jwksUri": {
     "inherited": false,
-    "value": "&{esv.sapig.ob.trusteddirurl}/jwkms/testdirectory/jwks"
+    "value": "&{esv.sapig.ob.trusteddirurl}/api/directory/jwks"
   },
   "publicKeyLocation": {
     "inherited": false,


### PR DESCRIPTION
## Summary
The `SoftwarePublisher` agent config for issuer `test-publisher` (used by AM/FIDC to validate software statement assertions) still points at `/jwkms/testdirectory/jwks` — the retired SecureApiGateway `test-trusted-directory` chart's JWKS path.

SAPIG 5.3.0 migrated to the new PingGateway `sample-trusted-directory` chart (see [secure-api-gateway-relenv-deployments#143](https://github.com/ForgeCloud/secure-api-gateway-relenv-deployments/pull/143)), which exposes its directory-level signing JWKS at a different path: `/api/directory/jwks` (`DirectoryRouter.java` in `openig-helm/sample-trusted-directory`). The new chart's ingress only routes `/api/` and `/ui/` prefixes — `/jwkms/...` isn't served at all anymore.

Since AM couldn't resolve the stale `jwksUri`, it had no valid key material for issuer `test-publisher` and rejected every software statement assertion signed by the new sample-trusted-directory with `"Jwt signature invalid."` / `invalid_software_statement` — even though the SSA signature verifies correctly against the actual (new) JWKS endpoint (confirmed manually).

## Change
Updates `jwksUri` in both realm overlays:
- `sapig-overlay/core/.../Secure API Gateway Development Trusted Directory.json`: `&{esv.sapig.core.trusteddirurl}/jwkms/testdirectory/jwks` → `&{esv.sapig.core.trusteddirurl}/api/directory/jwks`
- `sapig-overlay/ob/.../Secure API Gateway Development Trusted Directory.json`: `&{esv.sapig.ob.trusteddirurl}/jwkms/testdirectory/jwks` → `&{esv.sapig.ob.trusteddirurl}/api/directory/jwks`

## Test plan
- [x] Build config archives: `./create-config-archive.sh --type core --realm bravo` and `--type ob --realm alpha`
- [x] Apply via `fr-config-manager` against the relenvs FIDC tenant
- [x] Re-run the FAPI functional test suite's DCR/software-statement flow against core-sandbox-v5 and confirm `invalid_software_statement` no longer occurs